### PR TITLE
Update 'NoteEditorCodeSnippet' setting form layout

### DIFF
--- a/src/app/note/editor/snippet-setting-dialog/snippet-setting-dialog.component.html
+++ b/src/app/note/editor/snippet-setting-dialog/snippet-setting-dialog.component.html
@@ -1,0 +1,59 @@
+<div class="NoteEditorSnippetSettingDialog">
+    <h1 gd-text size="medium" weight="bold">Setting Code Snippet</h1>
+    <form [formGroup]="settingForm"
+          (ngSubmit)="submit()"
+          class="NoteEditorSnippetSettingDialog__form">
+
+        <div class="NoteEditorSnippetSettingDialog__row">
+            <label gd-text size="small" for="languageInput">Language</label>
+            <gd-form-field>
+                <input gdFormFieldControl
+                       gdAutocomplete
+                       [autocomplete]="auto"
+                       formControlName="language"
+                       placeholder="Input code language"
+                       id="languageInput"
+                       name="language">
+
+                <gd-autocomplete #auto="gdAutocomplete">
+                    <gd-option-item *ngFor="let stack of filteredStacks | async"
+                                    [value]="stack.name"
+                                    class="NoteEditorSnippetSettingDialog__languageOptionItem">
+                        <gd-stack-chip [stack]="stack"></gd-stack-chip>
+                        <span gd-text>{{stack.name}}</span>
+                    </gd-option-item>
+                </gd-autocomplete>
+            </gd-form-field>
+        </div>
+
+        <div class="NoteEditorSnippetSettingDialog__row">
+            <label gd-text size="small" for="fileNameInput">File Name</label>
+            <gd-form-field>
+                <input gdFormFieldControl
+                       formControlName="fileName"
+                       placeholder="Input file name"
+                       id="fileNameInput"
+                       name="fileName">
+
+                <gd-form-field-error errorName="required">
+                    <span gd-text size="small">File name is required</span>
+                </gd-form-field-error>
+            </gd-form-field>
+        </div>
+
+        <div class="NoteEditorSnippetSettingDialog__actions">
+            <button gd-button
+                    aria-label="save-settings-button"
+                    buttonType="primary">
+                <span gd-text>Save</span>
+            </button>
+            <button gd-button
+                    type="button"
+                    (click)="cancel()"
+                    aria-label="cancel-settings-button"
+                    cdkFocusInitial>
+                <span gd-text>Cancel</span>
+            </button>
+        </div>
+    </form>
+</div>

--- a/src/app/note/editor/snippet-setting-dialog/snippet-setting-dialog.component.less
+++ b/src/app/note/editor/snippet-setting-dialog/snippet-setting-dialog.component.less
@@ -1,0 +1,72 @@
+&:host {
+    display: block;
+}
+
+
+.NoteEditorSnippetSettingDialog {
+    width: 400px;
+    padding: var(--size-space-big);
+    background-color: var(--color-white);
+    border-radius: 3.5px;
+    box-shadow: 0 2px 6px 0 rgba(0, 0, 0, .75);
+
+    > h1 {
+        display: block;
+        margin: 0 0 var(--size-space-big) 0;
+    }
+
+    &__form {
+    }
+
+    &__row {
+        display: flex;
+        margin-bottom: var(--size-space-medium);
+
+        > label {
+            display: inline-block;
+            margin-right: var(--size-space-regular);
+            line-height: var(--size-box-regular);
+            width: 58px;
+            height: var(--size-box-regular);
+        }
+
+        > gd-form-field {
+            flex: 1;
+            display: block;
+
+            input {
+                width: 100%;
+                height: var(--size-box-regular);
+                padding: 0 var(--size-space-regular);
+                border: 1px solid var(--color-gray-4);
+                background-color: var(--color-gray-0);
+                font-size: var(--size-font-small);
+                border-radius: 2.5px;
+                outline: 0;
+
+                &:focus {
+                    box-shadow: 0 0 2px 0 var(--color-blue-5);
+                }
+            }
+
+            &.errorCaught {
+                input {
+                    border-color: var(--color-red-5);
+
+                    &:focus {
+                        box-shadow: 0 0 2px 0 var(--color-red-5);
+                    }
+                }
+            }
+        }
+    }
+
+    &__actions {
+        display: flex;
+        padding-top: var(--size-space-medium);
+
+        button:first-child {
+            margin-right: var(--size-space-small);
+        }
+    }
+}

--- a/src/app/note/editor/snippet-setting-dialog/snippet-setting-dialog.component.spec.ts
+++ b/src/app/note/editor/snippet-setting-dialog/snippet-setting-dialog.component.spec.ts
@@ -1,0 +1,103 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { typeInElement } from '../../../../testing/fake-event';
+import { expectDebugElement } from '../../../../testing/validation';
+import { MonacoService } from '../../../core/monaco.service';
+import { DIALOG_DATA } from '../../../shared/dialog/dialog';
+import { DialogRef } from '../../../shared/dialog/dialog-ref';
+import { SharedModule } from '../../../shared/shared.module';
+import { StackModule } from '../../../stack/stack.module';
+import { NoteContentSnippetTypes } from '../../models';
+import { NoteEditorSnippetConfig } from '../snippet/snippet';
+import { NoteEditorSnippetSettingDialogComponent } from './snippet-setting-dialog.component';
+
+
+describe('NoteEditorSnippetSettingDialogComponent', () => {
+    let fixture: ComponentFixture<NoteEditorSnippetSettingDialogComponent>;
+
+    let data: NoteEditorSnippetConfig;
+    let dialogRef: DialogRef<any>;
+
+    beforeEach(() => {
+        data = {
+            type: NoteContentSnippetTypes.CODE,
+            initialValue: '',
+            language: 'javascript',
+            fileName: 'test-file.js',
+            isNewSnippet: false,
+        };
+    });
+
+    beforeEach(async(() => {
+        const mockDialogRef = {
+            close: jasmine.createSpy('dialog close'),
+        };
+
+        TestBed
+            .configureTestingModule({
+                imports: [
+                    SharedModule,
+                    StackModule,
+                ],
+                providers: [
+                    MonacoService,
+                    { provide: DIALOG_DATA, useValue: data },
+                    { provide: DialogRef, useValue: mockDialogRef },
+                ],
+                declarations: [
+                    NoteEditorSnippetSettingDialogComponent,
+                ],
+            })
+            .compileComponents();
+    }));
+
+    beforeEach(() => {
+        dialogRef = TestBed.get(DialogRef);
+        fixture = TestBed.createComponent(NoteEditorSnippetSettingDialogComponent);
+        fixture.detectChanges();
+    });
+
+    it('should output modified settings through dialog reference ' +
+        'after submit setting form.', () => {
+
+       const languageInputEl = fixture.debugElement.query(
+           By.css('#languageInput')).nativeElement;
+       const fileNameInputEl = fixture.debugElement.query(
+           By.css('#fileNameInput')).nativeElement;
+
+       typeInElement('some-language', languageInputEl);
+       fixture.detectChanges();
+
+       typeInElement('some-filename', fileNameInputEl);
+       fixture.detectChanges();
+
+       // Submit settings form
+       const submitButton = fixture.debugElement.query(
+           By.css('button[aria-label=save-settings-button]'));
+
+       submitButton.nativeElement.click();
+       fixture.detectChanges();
+
+       expect(dialogRef.close).toHaveBeenCalledWith({
+           language: 'some-language',
+           fileName: 'some-filename',
+       });
+    });
+
+    it('should cancel button be initially focused.', () => {
+        const cancelButton = fixture.debugElement.query(
+            By.css('button[aria-label=cancel-settings-button]'));
+
+        expectDebugElement(cancelButton).toBeFocused();
+    });
+
+    it('should close dialog without any output when click close button.', () => {
+        const cancelButton = fixture.debugElement.query(
+            By.css('button[aria-label=cancel-settings-button]'));
+
+        cancelButton.nativeElement.click();
+        fixture.detectChanges();
+
+        expect(dialogRef.close).toHaveBeenCalledWith();
+    });
+});

--- a/src/app/note/editor/snippet-setting-dialog/snippet-setting-dialog.component.ts
+++ b/src/app/note/editor/snippet-setting-dialog/snippet-setting-dialog.component.ts
@@ -1,0 +1,45 @@
+import { Component, Inject, OnInit } from '@angular/core';
+import { FormControl, FormGroup } from '@angular/forms';
+import { Observable } from 'rxjs';
+import { DIALOG_DATA } from '../../../shared/dialog/dialog';
+import { DialogRef } from '../../../shared/dialog/dialog-ref';
+import { Stack } from '../../../stack/models';
+import { StackViewer } from '../../../stack/stack-viewer';
+import { NoteEditorSnippetConfig } from '../snippet/snippet';
+
+
+@Component({
+    selector: 'gd-editor-snippet-setting-dialog',
+    templateUrl: './snippet-setting-dialog.component.html',
+    styleUrls: ['./snippet-setting-dialog.component.less'],
+})
+export class NoteEditorSnippetSettingDialogComponent implements OnInit {
+    settingForm: FormGroup;
+    filteredStacks: Observable<Stack[]>;
+
+    constructor(
+        @Inject(DIALOG_DATA) readonly data: NoteEditorSnippetConfig,
+        private dialogRef: DialogRef<NoteEditorSnippetSettingDialogComponent>,
+        private stackViewer: StackViewer,
+    ) {
+    }
+
+    ngOnInit(): void {
+        this.settingForm = new FormGroup({
+            language: new FormControl(this.data.language || ''),
+            fileName: new FormControl(this.data.fileName || ''),
+        });
+
+        this.filteredStacks = this.stackViewer.searchAsObservable(
+            this.settingForm.get('language').valueChanges,
+        );
+    }
+
+    submit(): void {
+        this.dialogRef.close(this.settingForm.value);
+    }
+
+    cancel(): void {
+        this.dialogRef.close();
+    }
+}

--- a/src/app/note/editor/snippet/code-snippet.component.html
+++ b/src/app/note/editor/snippet/code-snippet.component.html
@@ -1,74 +1,24 @@
 <div #wrapper class="NoteEditorCodeSnippet">
-    <header [ngSwitch]="mode"
-            class="NoteEditorCodeSnippet__header">
+    <header class="NoteEditorCodeSnippet__header">
 
-        <div *ngSwitchCase="'edit'"
-             class="NoteEditorCodeSnippet__stackIcon">
+        <div class="NoteEditorCodeSnippet__stackIcon">
             <gd-stack-chip *ngIf="canDisplayLanguageStackIcon()"
                            [stack]="languageStack"></gd-stack-chip>
         </div>
 
-        <h1 *ngSwitchCase="'edit'"
-            gd-text
+        <h1 gd-text
             size="regular"
             weight="bold"
             class="NoteEditorCodeSnippet__title">
-            {{_config.fileName}}
+            {{_config.fileName || '(No File Name)'}}
         </h1>
 
-        <form *ngSwitchCase="'setting'"
-              (ngSubmit)="submitSetting()"
-              [formGroup]="settingForm"
-              class="NoteEditorCodeSnippet__settingForm">
-            <gd-form-field>
-                <label gd-text size="small">Language :</label>
-                <input gdFormFieldControl
-                       gdAutocomplete
-                       [autocomplete]="auto"
-                       formControlName="language"
-                       name="language">
-
-                <gd-autocomplete #auto="gdAutocomplete">
-                    <gd-option-item *ngFor="let stack of filteredStacks | async"
-                                    [value]="stack.name"
-                                    class="NoteEditorCodeSnippet__optionItem">
-                        <gd-stack-chip [stack]="stack"></gd-stack-chip>
-                        <span gd-text>{{stack.name}}</span>
-                    </gd-option-item>
-                </gd-autocomplete>
-            </gd-form-field>
-
-            <gd-form-field>
-                <label gd-text size="small">File Name :</label>
-                <input gdFormFieldControl
-                       formControlName="fileName"
-                       name="fileName">
-            </gd-form-field>
-
-            <div class="NoteEditorCodeSnippet__formButtonGroup">
-                <button gd-button
-                        size="small"
-                        aria-label="save-button"
-                        type="submit">
-                    <span gd-text>Save</span>
-                </button>
-                <button gd-button
-                        (click)="cancelSetting()"
-                        size="small"
-                        aria-label="cancel-button"
-                        type="button">
-                    <span gd-text>Cancel</span>
-                </button>
-            </div>
-        </form>
-
-        <button *ngSwitchCase="'edit'"
-                gd-button
+        <button gd-button
                 gdTooltip
                 position="left"
                 message="Setting snippet (⌥ + ⇧ + S)"
                 [showDelay]="500"
-                (click)="turnSettingModeOn()"
+                (click)="openSettingDialog()"
                 size="small"
                 buttonType="flat"
                 aria-label="setting-button"

--- a/src/app/note/editor/snippet/code-snippet.component.less
+++ b/src/app/note/editor/snippet/code-snippet.component.less
@@ -19,12 +19,13 @@
         margin: 0;
         padding: 0 var(--size-space-regular);
         color: var(--color-gray-8);
+        user-select: none;
+        cursor: default;
     }
 
     &__settingForm {
         display: flex;
-        align-items: center;
-        flex-wrap: wrap;
+        grid-gap: var(--size-space-small);
         padding: 0 var(--size-space-small);
         width: 100%;
 
@@ -33,18 +34,26 @@
             margin-right: var(--size-space-regular);
         }
 
+        label {
+            display: block;
+            margin-bottom: var(--size-space-small);
+        }
+
         input {
-            font-size: var(--size-font-small);
-            line-height: var(--size-lineHeight-small);
+            display: block;
+            width: 100%;
+            font-size: var(--size-font-regular);
+            line-height: var(--size-lineHeight-regular);
             padding: 0 var(--size-space-small);
-            height: var(--size-box-small);
-            background-color: var(--color-gray-1);
+            height: var(--size-box-regular);
+            background-color: var(--color-gray-0);
             border: 1px solid var(--color-gray-4);
             outline: 0;
+            z-index: 4; // Higher than cdk overlay
 
             &:focus {
+                background-color: var(--color-gray-1);
                 border-color: var(--color-blue-5);
-                box-shadow: 0 0 2px 0 var(--color-blue-5);
             }
         }
     }
@@ -62,10 +71,12 @@
     }
 
     &__formButtonGroup {
-        flex: 1;
+        // flex: 1;
         display: inline-flex;
-        justify-content: flex-end;
+        // justify-content: flex-end;
         align-self: center;
+        grid-column: 3 / 3;
+        grid-row: 1;
 
         button {
             display: inline-block;

--- a/src/app/note/editor/snippet/code-snippet.component.spec.ts
+++ b/src/app/note/editor/snippet/code-snippet.component.spec.ts
@@ -1,13 +1,12 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { combineReducers, Store, StoreModule } from '@ngrx/store';
 import { KeyCodes } from '../../../../common/key-codes';
-import { dispatchKeyboardEvent, typeInElement } from '../../../../testing/fake-event';
+import { dispatchKeyboardEvent } from '../../../../testing/fake-event';
+import { MockDialog } from '../../../../testing/mock';
 import { MonacoService } from '../../../core/monaco.service';
-import { SharedModule } from '../../../shared/shared.module';
-import { StackChipComponent } from '../../../stack/chip/chip.component';
-import { StackViewer } from '../../../stack/stack-viewer';
+import { Dialog } from '../../../shared/dialog/dialog';
+import { StackModule } from '../../../stack/stack.module';
 import {
     MoveFocusToNextSnippetAction,
     MoveFocusToPreviousSnippetAction,
@@ -16,6 +15,7 @@ import {
 } from '../../actions';
 import { NoteContentSnippetTypes } from '../../models';
 import { noteReducerMap, NoteStateWithRoot } from '../../reducers';
+import { NoteEditorSnippetSettingDialogComponent } from '../snippet-setting-dialog/snippet-setting-dialog.component';
 import { NoteEditorCodeSnippetComponent } from './code-snippet.component';
 import {
     NOTE_EDITOR_SNIPPET_CONFIG,
@@ -33,6 +33,7 @@ describe('app.note.editor.snippet.EditorCodeSnippetComponent', () => {
     let config: NoteEditorSnippetConfig;
 
     let store: Store<NoteStateWithRoot>;
+    let mockDialog: MockDialog;
 
     const getInputField = (): HTMLTextAreaElement =>
         document.querySelector('.monaco-editor .inputarea') as HTMLTextAreaElement;
@@ -48,20 +49,19 @@ describe('app.note.editor.snippet.EditorCodeSnippetComponent', () => {
     const configureTestBed = () => TestBed
         .configureTestingModule({
             imports: [
-                SharedModule,
-                NoopAnimationsModule,
+                ...MockDialog.importsForTesting,
+                StackModule,
                 StoreModule.forRoot({
                     note: combineReducers(noteReducerMap),
                 }),
             ],
             providers: [
+                ...MockDialog.providersForTesting,
                 MonacoService,
-                StackViewer,
                 { provide: NOTE_EDITOR_SNIPPET_REF, useValue: ref },
                 { provide: NOTE_EDITOR_SNIPPET_CONFIG, useValue: config },
             ],
             declarations: [
-                StackChipComponent,
                 NoteEditorCodeSnippetComponent,
             ],
         })
@@ -95,13 +95,15 @@ describe('app.note.editor.snippet.EditorCodeSnippetComponent', () => {
             configureTestBed();
         }));
 
-        it('should show initial value when initialized editor.', () => {
+        beforeEach(() => {
             createFixture();
+        });
+
+        it('should show initial value when initialized editor.', () => {
             expect(component.getValue()).toEqual(config.initialValue);
         });
 
         it('should language has been set.', () => {
-            createFixture();
             expect(component.getLanguage()).toEqual(config.language);
         });
     });
@@ -111,9 +113,11 @@ describe('app.note.editor.snippet.EditorCodeSnippetComponent', () => {
             configureTestBed();
         }));
 
-        it('should be true when cursor in the start line of editor.', () => {
+        beforeEach(() => {
             createFixture();
+        });
 
+        it('should be true when cursor in the start line of editor.', () => {
             component._editor.setPosition({
                 lineNumber: 1,
                 column: 0,
@@ -128,16 +132,16 @@ describe('app.note.editor.snippet.EditorCodeSnippetComponent', () => {
             configureTestBed();
         }));
 
-        it('if editor has only one line, it should be true on both top and bottom.', () => {
+        beforeEach(() => {
             createFixture();
+        });
 
+        it('if editor has only one line, it should be true on both top and bottom.', () => {
             expect(component.isCurrentPositionTop()).toBe(true);
             expect(component.isCurrentPositionBottom()).toBe(true);
         });
 
         it('should be true when cursor in the last line of editor', () => {
-            createFixture();
-
             component.setValue('hello\nworld!');
             component._editor.setPosition({
                 lineNumber: 2,
@@ -153,9 +157,11 @@ describe('app.note.editor.snippet.EditorCodeSnippetComponent', () => {
             configureTestBed();
         }));
 
-        it('should cursor located at first line.', () => {
+        beforeEach(() => {
             createFixture();
+        });
 
+        it('should cursor located at first line.', () => {
             component.setValue('Some long\nparagraph');
             component._editor.setPosition({
                 lineNumber: 2,
@@ -173,9 +179,11 @@ describe('app.note.editor.snippet.EditorCodeSnippetComponent', () => {
             configureTestBed();
         }));
 
-        it('should cursor located at last line.', () => {
+        beforeEach(() => {
             createFixture();
+        });
 
+        it('should cursor located at last line.', () => {
             component.setValue('Some long\nparagraph.');
             expect(component.isCurrentPositionBottom()).toBe(false);
 
@@ -185,8 +193,11 @@ describe('app.note.editor.snippet.EditorCodeSnippetComponent', () => {
     });
 
     describe('typing', () => {
-        beforeEach(() => {
+        beforeEach(async(() => {
             configureTestBed();
+        }));
+
+        beforeEach(() => {
             createFixture();
 
             store = TestBed.get(Store);
@@ -235,56 +246,45 @@ describe('app.note.editor.snippet.EditorCodeSnippetComponent', () => {
 
     describe('setting', () => {
         beforeEach(async(() => {
-            overwriteConfig({ isNewSnippet: true });
             configureTestBed();
         }));
 
-        it('should setting form appeared if \'isNewSnippet\' value is true ' +
-            'which from snippet config, when snippet is initialized', () => {
-
+        beforeEach(() => {
             createFixture();
 
-            const settingForm = fixture.debugElement.query(
-                By.css('form.NoteEditorCodeSnippet__settingForm'));
+            mockDialog = TestBed.get(Dialog);
+            store = TestBed.get(Store);
 
-            expect(component.mode).toEqual('setting');
-            expect(settingForm).not.toBeNull();
+            spyOn(store, 'dispatch').and.callThrough();
         });
 
-        it('should dispatch \'UPDATE_SNIPPET_CONTENT\' action ' +
-            'after submit setting form', () => {
-
-            store = TestBed.get(Store);
-            spyOn(store, 'dispatch').and.callThrough();
-
-            createFixture();
-
-            const languageInputEl = fixture.debugElement.query(
-                By.css('input[name="language"]')).nativeElement;
-            const fileNameInputEl = fixture.debugElement.query(
-                By.css('input[name="fileName"]')).nativeElement;
-
-            typeInElement('some-language', languageInputEl);
-            fixture.detectChanges();
-
-            typeInElement('some-filename', fileNameInputEl);
-            fixture.detectChanges();
-
-            const submitButton = fixture.debugElement.query(
-                By.css('button[aria-label=save-button]'));
-            submitButton.nativeElement.click();
-            fixture.detectChanges();
-
-            const expectedPayload = {
-                snippetId: component.id,
-                patch: {
-                    language: 'some-language',
-                    fileName: 'some-filename',
-                },
+        it('should update settings and dispatch \'UPDATE_SNIPPET_CONTENT\' action ' +
+            'after snippet setting dialog submitted with patch.', () => {
+            const patch = {
+                language: 'modified-language',
+                fileName: 'modified-fileName',
             };
-            const expectedAction = new UpdateSnippetContentAction(expectedPayload);
 
-            expect(store.dispatch).toHaveBeenCalledWith(expectedAction);
+            const settingButton = fixture.debugElement.query(
+                By.css('button[aria-label=setting-button]'));
+
+            settingButton.nativeElement.click();
+            fixture.detectChanges();
+
+            expect(mockDialog.openDialog).toEqual(NoteEditorSnippetSettingDialogComponent);
+            expect(mockDialog.openDialogConfig.data).toEqual(component._config);
+
+            mockDialog.dialogRef.close(patch);
+            fixture.detectChanges();
+
+            expect(component._config.language).toEqual('modified-language');
+
+            const expected = new UpdateSnippetContentAction({
+                snippetId: component.id,
+                patch,
+            });
+
+            expect(store.dispatch).toHaveBeenCalledWith(expected);
         });
     });
 });

--- a/src/app/note/note.module.ts
+++ b/src/app/note/note.module.ts
@@ -6,6 +6,9 @@ import { StackModule } from '../stack/stack.module';
 import { NoteCalendarComponent } from './calendar/calendar.component';
 import { NoteEditorComponent } from './editor/editor.component';
 import { NoteEditorService } from './editor/editor.service';
+import {
+    NoteEditorSnippetSettingDialogComponent,
+} from './editor/snippet-setting-dialog/snippet-setting-dialog.component';
 import { NoteEditorCodeSnippetComponent } from './editor/snippet/code-snippet.component';
 import { NoteEditorSnippetFactory } from './editor/snippet/snippet-factory';
 import { NoteEditorTextSnippetComponent } from './editor/snippet/text-snippet.component';
@@ -43,6 +46,7 @@ import { NoteWorkspaceComponent } from './workspace/workspace.component';
         NoteEditorCodeSnippetComponent,
         NoteEditorTextSnippetComponent,
         NoteEditorToolbarComponent,
+        NoteEditorSnippetSettingDialogComponent,
         NoteEditorComponent,
         NotePreviewLanguageChartComponent,
         NotePreviewComponent,
@@ -52,6 +56,7 @@ import { NoteWorkspaceComponent } from './workspace/workspace.component';
         NoteFinderComponent,
         NoteEditorCodeSnippetComponent,
         NoteEditorTextSnippetComponent,
+        NoteEditorSnippetSettingDialogComponent,
     ],
     providers: [
         NoteFsService,

--- a/src/app/shared/autocomplete/autocomplete.component.less
+++ b/src/app/shared/autocomplete/autocomplete.component.less
@@ -3,6 +3,11 @@
     overflow-y: scroll;
     visibility: hidden;
     box-shadow: 0 0 2px 0 var(--color-gray-5);
+    border-bottom-left-radius: 2px;
+    border-bottom-right-radius: 2px;
+    border-left: 1px solid var(--color-gray-4);
+    border-right: 1px solid var(--color-gray-4);
+    border-bottom: 1px solid var(--color-gray-4);
 
     &--visible {
         visibility: visible;

--- a/src/app/shared/button/button.component.less
+++ b/src/app/shared/button/button.component.less
@@ -32,11 +32,11 @@
         }
 
         &-primary {
-            background-color: var(--color-teal-4);
+            background-color: var(--color-indigo-5);
             color: var(--color-white);
 
             &:focus {
-                box-shadow: 0 0 2px 0 var(--color-teal-7);
+                box-shadow: 0 0 2px 0 var(--color-blue-5);
             }
         }
 

--- a/src/app/shared/dialog/dialog-config.ts
+++ b/src/app/shared/dialog/dialog-config.ts
@@ -7,7 +7,7 @@ export interface DialogPosition {
 
 export class DialogConfig<D = any> {
     hasBackdrop = true;
-    closeOnEscape = false;
+    closeOnEscape = true;
     width = '';
     height = '';
     minWidth?: number | string;

--- a/src/app/shared/option-item/option-item.component.less
+++ b/src/app/shared/option-item/option-item.component.less
@@ -9,6 +9,7 @@
     cursor: pointer;
 
     &--active {
-        background-color: var(--color-blue-0);
+        background-color: var(--color-gray-1);
+        color: var(--color-blue-5);
     }
 }

--- a/src/testing/mock/index.ts
+++ b/src/testing/mock/index.ts
@@ -1,3 +1,5 @@
 export * from './mock-actions';
+export * from './mock-dialog';
+export * from './mock-dialog-ref';
 export * from './mock-fs.service';
 export * from './mock-ng-zone';

--- a/src/testing/mock/mock-dialog-ref.ts
+++ b/src/testing/mock/mock-dialog-ref.ts
@@ -1,0 +1,26 @@
+import { Observable } from 'rxjs/Observable';
+import { Subject } from 'rxjs/Subject';
+
+
+export class MockDialogRef {
+    private readonly _afterOpen = new Subject<void>();
+    private readonly _afterClosed = new Subject<any>();
+    private readonly _beforeClose = new Subject<any>();
+
+    afterOpen(): Observable<void> {
+        return this._afterOpen.asObservable();
+    }
+
+    afterClosed(): Observable<any> {
+        return this._afterClosed.asObservable();
+    }
+
+    beforeClose(): Observable<any> {
+        return this._beforeClose.asObservable();
+    }
+
+    close(result: any): void {
+        this._beforeClose.next(result);
+        this._afterClosed.next(result);
+    }
+}

--- a/src/testing/mock/mock-dialog.ts
+++ b/src/testing/mock/mock-dialog.ts
@@ -1,0 +1,32 @@
+import { ComponentType } from '@angular/cdk/portal';
+import { Injectable } from '@angular/core';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { Dialog } from '../../app/shared/dialog/dialog';
+import { DialogConfig } from '../../app/shared/dialog/dialog-config';
+import { SharedModule } from '../../app/shared/shared.module';
+import { MockDialogRef } from './mock-dialog-ref';
+
+
+@Injectable()
+export class MockDialog extends Dialog {
+    static importsForTesting = [
+        NoopAnimationsModule,
+        SharedModule,
+    ];
+
+    static providersForTesting = [
+        { provide: Dialog, useClass: MockDialog },
+    ];
+
+    openDialog: ComponentType<any>;
+    openDialogConfig: Partial<DialogConfig<any>>;
+    dialogRef: MockDialogRef;
+
+    open(component: ComponentType<any>, config?: Partial<DialogConfig>): any {
+        this.openDialog = component;
+        this.openDialogConfig = config;
+        this.dialogRef = new MockDialogRef();
+
+        return this.dialogRef;
+    }
+}

--- a/src/testing/validation/expect-debug-element.ts
+++ b/src/testing/validation/expect-debug-element.ts
@@ -33,6 +33,10 @@ class DebugElementMatcher {
     toBeDisabled(): boolean {
         return expect((<any>this.nativeElem).disabled).toBe(true);
     }
+
+    toBeFocused(): boolean {
+        return document.activeElement === this.nativeElem;
+    }
 }
 
 

--- a/tslint.json
+++ b/tslint.json
@@ -37,7 +37,7 @@
         "label-position": true,
         "max-line-length": [
             true,
-            100
+            120
         ],
         "member-access": false,
         "member-ordering": [true, { "order": [] }],


### PR DESCRIPTION
Use dialog as code snippet setting.

Related issue: #29 

See screenshot:
<img width="474" alt="2018-06-24 10 01 56" src="https://user-images.githubusercontent.com/13250888/41819374-3af92946-77fa-11e8-8663-992016cac62b.png">
