### PR TITLE
Add checkbox ui

### DIFF
--- a/src/browser/ui/_all-theme.scss
+++ b/src/browser/ui/_all-theme.scss
@@ -10,6 +10,7 @@
 @import "./radio/radio-theme";
 @import "./line/line-theme";
 @import "./tabs/tab-group-theme";
+@import "./checkbox/checkbox-theme";
 
 @mixin gd-ui-all-theme($theme) {
     @include gd-ui-autocomplete-theme($theme);
@@ -24,4 +25,5 @@
     @include gd-ui-radio-theme($theme);
     @include gd-ui-line-theme($theme);
     @include gd-ui-tab-group-theme($theme);
+    @include gd-ui-checkbox-theme($theme);
 }

--- a/src/browser/ui/checkbox/_checkbox-sizes.scss
+++ b/src/browser/ui/checkbox/_checkbox-sizes.scss
@@ -1,0 +1,8 @@
+// The width/height of the checkbox element.
+$checkbox-size: 14px !default;
+
+// The width of the checkbox border shown when the checkbox is unchecked.
+$checkbox-border-width: 2px;
+
+// The base duration used for the majority of transitions for the checkbox.
+$checkbox-transition-duration: 90ms;

--- a/src/browser/ui/checkbox/_checkbox-theme.scss
+++ b/src/browser/ui/checkbox/_checkbox-theme.scss
@@ -1,0 +1,51 @@
+@import "../style/theming";
+
+@mixin gd-ui-checkbox-theme($theme) {
+    $is-dark-theme: map-get($theme, is-dark);
+    $primary: map-get($theme, primary);
+    $background: map-get($theme, background);
+
+    // The color of the checkbox's checkmark / mixedmark.
+    $checkbox-mark-color: gd-color($background, background);
+
+    // While the spec calls for translucent blacks/whites for disabled colors,
+    // this does not work well with elements layered on top of one another. To get around this we
+    // blend the colors together based on the base color and the theme background.
+    $white-30pct-opacity-on-dark: #686868;
+    $black-26pct-opacity-on-light: #b0b0b0;
+    $disabled-color: if($is-dark-theme, $white-30pct-opacity-on-dark, $black-26pct-opacity-on-light);
+
+    .Checkbox {
+        &__frame {
+            border-color: gd-color(map-get($theme, foreground), secondary-text);
+        }
+
+        &__checkMark {
+            fill: $checkbox-mark-color;
+
+            > path {
+                // !important is needed here because a stroke must be set as an
+                // attribute on the SVG in order for line animation to work properly.
+                stroke: $checkbox-mark-color !important;
+            }
+        }
+
+        &__mixedMark {
+            background-color: $checkbox-mark-color;
+        }
+    }
+
+    .Checkbox--indeterminate, .Checkbox--checked {
+        .Checkbox__background {
+            background-color: gd-color($primary);
+        }
+    }
+
+    .Checkbox--disabled {
+        &.Checkbox--checked:not(.Checkbox--indeterminate) {
+            .Checkbox__background {
+                background-color: $disabled-color;
+            }
+        }
+    }
+}

--- a/src/browser/ui/checkbox/checkbox-config.ts
+++ b/src/browser/ui/checkbox/checkbox-config.ts
@@ -1,0 +1,20 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import { InjectionToken } from '@angular/core';
+
+
+/**
+ * Checkbox click action when user click on input element.
+ * noop: Do not toggle checked or indeterminate.
+ * check: Only toggle checked status, ignore indeterminate.
+ * check-indeterminate: Toggle checked status, set indeterminate to false. Default behavior.
+ * undefined: Same as `check-indeterminate`.
+ */
+export type CheckboxClickAction = 'noop' | 'check' | 'check-indeterminate' | undefined;
+
+export const CHECKBOX_CLICK_ACTION = new InjectionToken<CheckboxClickAction>('CheckboxClickAction');

--- a/src/browser/ui/checkbox/checkbox.component.html
+++ b/src/browser/ui/checkbox/checkbox.component.html
@@ -1,0 +1,31 @@
+<label [attr.for]="inputId" class="Checkbox__layout">
+    <div class="Checkbox__innerContainer"
+          [class.Checkbox__innerContainer--noSideMargin]="!checkboxLabel.textContent || !checkboxLabel.textContent.trim()">
+        <input #input
+               type="checkbox"
+               [id]="inputId"
+               [checked]="checked"
+               [attr.value]="value"
+               [disabled]="disabled"
+               [attr.name]="name"
+               [tabIndex]="0"
+               [indeterminate]="indeterminate"
+               [attr.aria-label]="ariaLabel || null"
+               [attr.aria-labelledby]="ariaLabelledby"
+               [attr.aria-checked]="_getAriaChecked()"
+               (change)="_onInteractionEvent($event)"
+               (click)="_onInputClick($event)">
+        <div class="Checkbox__frame"></div>
+        <div class="Checkbox__background">
+            <svg version="1.1" focusable="false" class="Checkbox__checkMark" viewBox="0 0 24 24" xml:space="preserve">
+                <path fill="none" stroke="white" d="M4.1,12.7 9,17.6 20.3,6.3"></path>
+            </svg>
+            <!-- Element for rendering the indeterminate state checkbox. -->
+            <span class="Checkbox__mixedMark"></span>
+        </div>
+    </div>
+
+    <span class="Checkbox__label" #checkboxLabel (cdkObserverContent)="_onLabelTextChange()">
+        <ng-content></ng-content>
+    </span>
+</label>

--- a/src/browser/ui/checkbox/checkbox.component.html
+++ b/src/browser/ui/checkbox/checkbox.component.html
@@ -3,6 +3,7 @@
           [class.Checkbox__innerContainer--noSideMargin]="!checkboxLabel.textContent || !checkboxLabel.textContent.trim()">
         <input #input
                type="checkbox"
+               class="cdk-visually-hidden"
                [id]="inputId"
                [checked]="checked"
                [attr.value]="value"

--- a/src/browser/ui/checkbox/checkbox.component.scss
+++ b/src/browser/ui/checkbox/checkbox.component.scss
@@ -33,12 +33,10 @@ $_checkbox-mark-stroke-size: 2.5 / 12 * $checkbox-size !default;
         flex-shrink: 0;
 
         > input {
-            position: absolute;
-            display: none;
-            width: 0;
-            height: 0;
-            left: 0;
-            top: 0;
+            // Move the input to the bottom and in the middle.
+            // Visual improvement to properly show browser popups when being required.
+            bottom: 0;
+            left: 50%;
         }
 
         &--noSideMargin {

--- a/src/browser/ui/checkbox/checkbox.component.scss
+++ b/src/browser/ui/checkbox/checkbox.component.scss
@@ -1,0 +1,156 @@
+@import "../style/spacing";
+@import "../style/typography";
+@import "./checkbox-sizes";
+
+$_checkbox-mark-path-length: 22.910259;
+$_checkbox-mark-stroke-size: 2.5 / 12 * $checkbox-size !default;
+
+.Checkbox {
+    cursor: pointer;
+
+    * {
+        cursor: inherit;
+    }
+
+    &__layout {
+        cursor: inherit;
+        align-items: baseline;
+        vertical-align: middle;
+        display: inline-flex;
+        white-space: nowrap;
+    }
+
+    &__innerContainer {
+        display: inline-block;
+        height: $checkbox-size;
+        line-height: 0;
+        margin: auto $spacing-half auto auto;
+        order: 0;
+        position: relative;
+        vertical-align: middle;
+        white-space: nowrap;
+        width: $checkbox-size;
+        flex-shrink: 0;
+
+        > input {
+            position: absolute;
+            display: none;
+            width: 0;
+            height: 0;
+            left: 0;
+            top: 0;
+        }
+
+        &--noSideMargin {
+            margin: {
+                left: 0;
+                right: 0;
+            };
+        }
+    }
+
+    &__background {
+        border-radius: 2px;
+        box-sizing: border-box;
+        pointer-events: none;
+
+        position: absolute;
+        left: 0;
+        top: 0;
+        right: 0;
+        bottom: 0;
+
+        align-items: center;
+        display: inline-flex;
+        justify-content: center;
+    }
+
+    &__frame {
+        position: absolute;
+        left: 0;
+        top: 0;
+        right: 0;
+        bottom: 0;
+
+        background-color: transparent;
+        border: {
+            width: $checkbox-border-width;
+            style: solid;
+        };
+        border-radius: 2px;
+    }
+
+    &__checkMark {
+        position: absolute;
+        left: 0;
+        top: 0;
+        right: 0;
+        bottom: 0;
+        width: 100%;
+
+        > path {
+            stroke: {
+                dashoffset: $_checkbox-mark-path-length;
+                dasharray: $_checkbox-mark-path-length;
+                width: $_checkbox-mark-stroke-size;
+            }
+        }
+    }
+
+    &__mixedMark {
+        $height: floor($_checkbox-mark-stroke-size);
+
+        width: calc(100% - 6px);
+        height: $height;
+        opacity: 0;
+        transform: scaleX(0) rotate(0deg);
+        border-radius: 2px;
+    }
+
+    &__label {
+        font: {
+            size: $font-size;
+        };
+        line-height: inherit;
+    }
+
+    &--checked {
+        .Checkbox__checkMark {
+            opacity: 1;
+
+            > path {
+                stroke-dashoffset: 0;
+            }
+        }
+
+        .Checkbox__mixedMark {
+            transform: scaleX(1) rotate(-45deg);
+        }
+    }
+
+    &--indeterminate {
+        .Checkbox__checkMark {
+            opacity: 0;
+            transform: rotate(45deg);
+
+            > path {
+                stroke-dashoffset: 0;
+            }
+        }
+
+        .Checkbox__mixedMark {
+            opacity: 1;
+            transform: scaleX(1) rotate(0deg);
+        }
+
+        &.Checkbox--disabled {
+            .Checkbox__innerContainer {
+                opacity: 0.5;
+            }
+        }
+    }
+
+    &--disabled {
+        cursor: default;
+    }
+}

--- a/src/browser/ui/checkbox/checkbox.component.ts
+++ b/src/browser/ui/checkbox/checkbox.component.ts
@@ -1,0 +1,308 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import { FocusMonitor } from '@angular/cdk/a11y';
+import { coerceBooleanProperty } from '@angular/cdk/coercion';
+import {
+    ChangeDetectionStrategy,
+    ChangeDetectorRef,
+    Component,
+    ElementRef,
+    EventEmitter,
+    Inject,
+    Input,
+    NgZone,
+    OnDestroy,
+    Optional,
+    Output,
+    ViewChild,
+    ViewEncapsulation,
+} from '@angular/core';
+import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
+import { CHECKBOX_CLICK_ACTION, CheckboxClickAction } from './checkbox-config';
+
+
+let uniqueId = 0;
+
+
+/** Change event object emitted by Checkbox. */
+export class CheckboxChange {
+    /** The source Checkbox of the event. */
+    source: CheckboxComponent;
+    /** The new `checked` value of the checkbox. */
+    checked: boolean;
+}
+
+
+/**
+ * A material design checkbox component. Supports all of the functionality of an HTML5 checkbox,
+ * and exposes a similar API. A MatCheckbox can be either checked, unchecked, indeterminate, or
+ * disabled. Note that all additional accessibility attributes are taken care of by the component,
+ * so there is no need to provide them yourself. However, if you want to omit a label and still
+ * have the checkbox be accessible, you may supply an [aria-label] input.
+ * See: https://material.io/design/components/selection-controls.html
+ */
+@Component({
+    selector: 'gd-checkbox',
+    exportAs: 'gdCheckbox',
+    templateUrl: './checkbox.component.html',
+    styleUrls: ['./checkbox.component.scss'],
+    encapsulation: ViewEncapsulation.None,
+    changeDetection: ChangeDetectionStrategy.OnPush,
+    providers: [
+        {
+            provide: NG_VALUE_ACCESSOR,
+            useExisting: CheckboxComponent,
+            multi: true,
+        },
+    ],
+    host: {
+        'class': 'Checkbox',
+        '[class.Checkbox--checked]': 'checked',
+        '[class.Checkbox--indeterminate]': 'indeterminate',
+        '[class.Checkbox--disabled]': 'disabled',
+        '[id]': 'id',
+        '[attr.tabindex]': 'null',
+    },
+})
+export class CheckboxComponent implements ControlValueAccessor, OnDestroy {
+    /** Name value will be applied to the input element if present */
+    @Input() name: string | null = null;
+
+    /** The value attribute of the native input element */
+    @Input() value: string;
+
+    /** Event emitted when the checkbox's `checked` value changes. */
+    @Output() readonly change = new EventEmitter<CheckboxChange>();
+
+    /** Event emitted when the checkbox's `indeterminate` value changes. */
+    @Output() readonly indeterminateChange = new EventEmitter<boolean>();
+
+    /** The native `<input type="checkbox">` element */
+    @ViewChild('input') _inputElement: ElementRef<HTMLInputElement>;
+
+    /**
+     * Attached to the aria-label attribute of the host element. In most cases, arial-labelledby will
+     * take precedence so this may be omitted.
+     */
+    @Input('aria-label') ariaLabel: string = '';
+
+    /**
+     * Users can specify the `aria-labelledby` attribute which will be forwarded to the input element
+     */
+    @Input('aria-labelledby') ariaLabelledby: string | null = null;
+
+    private _uniqueId: string = `gd-chceckbox-${uniqueId++}`;
+
+    /** A unique id for the checkbox input. If none is supplied, it will be auto-generated. */
+    @Input() id: string = this._uniqueId;
+
+    constructor(
+        public _elementRef: ElementRef<HTMLElement>,
+        private changeDetectorRef: ChangeDetectorRef,
+        private focusMonitor: FocusMonitor,
+        private ngZone: NgZone,
+        @Optional() @Inject(CHECKBOX_CLICK_ACTION) private _clickAction: CheckboxClickAction,
+    ) {
+        this.focusMonitor.monitor(this._elementRef.nativeElement, true).subscribe((focusOrigin) => {
+            if (!focusOrigin) {
+                // When a focused element becomes disabled, the browser *immediately* fires a blur event.
+                // Angular does not expect events to be raised during change detection, so any state change
+                // (such as a form control's 'ng-touched') will cause a changed-after-checked error.
+                // See https://github.com/angular/angular/issues/17793. To work around this, we defer
+                // telling the form control it has been touched until the next tick.
+                Promise.resolve().then(() => this._onTouched());
+            }
+        });
+    }
+
+    private _checked: boolean = false;
+
+    /**
+     * Whether the checkbox is checked.
+     */
+    @Input()
+    get checked(): boolean {
+        return this._checked;
+    }
+
+    set checked(value: boolean) {
+        if (value !== this.checked) {
+            this._checked = value;
+            this.changeDetectorRef.markForCheck();
+        }
+    }
+
+    private _disabled: boolean = false;
+
+    /**
+     * Whether the checkbox is disabled. This fully overrides the implementation provided by
+     * mixinDisabled, but the mixin is still required because mixinTabIndex requires it.
+     */
+    @Input()
+    get disabled() {
+        return this._disabled;
+    }
+
+    set disabled(value: any) {
+        const newValue = coerceBooleanProperty(value);
+
+        if (newValue !== this.disabled) {
+            this._disabled = newValue;
+            this.changeDetectorRef.markForCheck();
+        }
+    }
+
+    private _indeterminate: boolean = false;
+
+    /**
+     * Whether the checkbox is indeterminate. This is also known as "mixed" mode and can be used to
+     * represent a checkbox with three states, e.g. a checkbox that represents a nested list of
+     * checkable items. Note that whenever checkbox is manually clicked, indeterminate is immediately
+     * set to false.
+     */
+    @Input()
+    get indeterminate(): boolean {
+        return this._indeterminate;
+    }
+
+    set indeterminate(value: boolean) {
+        const changed = value !== this._indeterminate;
+        this._indeterminate = value;
+
+        if (changed) {
+            this.indeterminateChange.emit(this._indeterminate);
+        }
+    }
+
+    get inputId(): string {
+        return `${this.id || this._uniqueId}-input`;
+    }
+
+    /**
+     * Called when the checkbox is blurred. Needed to properly implement ControlValueAccessor.
+     * @docs-private
+     */
+    /* tslint:disable */
+    _onTouched: () => any = () => {
+    };
+
+    /* tslint:enable */
+
+    ngOnDestroy(): void {
+        this.focusMonitor.stopMonitoring(this._elementRef.nativeElement);
+    }
+
+    // Implemented as part of ControlValueAccessor.
+    writeValue(value: any): void {
+        this.checked = !!value;
+    }
+
+    // Implemented as part of ControlValueAccessor.
+    registerOnChange(fn: (value: any) => void): void {
+        this._controlValueAccessorChangeFn = fn;
+    }
+
+    // Implemented as part of ControlValueAccessor.
+    registerOnTouched(fn: any): void {
+        this._onTouched = fn;
+    }
+
+    // Implemented as part of ControlValueAccessor.
+    setDisabledState(isDisabled: boolean): void {
+        this.disabled = isDisabled;
+    }
+
+    /** Toggles the `checked` state of the checkbox. */
+    toggle(): void {
+        this.checked = !this.checked;
+    }
+
+    _getAriaChecked(): 'true' | 'false' | 'mixed' {
+        return this.checked ? 'true' : (this.indeterminate ? 'mixed' : 'false');
+    }
+
+    /** Method being called whenever the label text changes. */
+    _onLabelTextChange(): void {
+        // Since the event of the `cdkObserveContent` directive runs outside of the zone, the checkbox
+        // component will be only marked for check, but no actual change detection runs automatically.
+        // Instead of going back into the zone in order to trigger a change detection which causes
+        // *all* components to be checked (if explicitly marked or not using OnPush), we only trigger
+        // an explicit change detection for the checkbox view and it's children.
+        this.changeDetectorRef.detectChanges();
+    }
+
+    /**
+     * Event handler for checkbox input element.
+     * Toggles checked state if element is not disabled.
+     * Do not toggle on (change) event since IE doesn't fire change event when
+     *   indeterminate checkbox is clicked.
+     * @param event
+     */
+    _onInputClick(event: Event): void {
+        // We have to stop propagation for click events on the visual hidden input element.
+        // By default, when a user clicks on a label element, a generated click event will be
+        // dispatched on the associated input element. Since we are using a label element as our
+        // root container, the click event on the `checkbox` will be executed twice.
+        // The real click event will bubble up, and the generated click event also tries to bubble up.
+        // This will lead to multiple click events.
+        // Preventing bubbling for the second event will solve that issue.
+        event.stopPropagation();
+
+        // If resetIndeterminate is false, and the current state is indeterminate, do nothing on click
+        if (!this.disabled && this._clickAction !== 'noop') {
+            // When user manually click on the checkbox, `indeterminate` is set to false.
+            if (this.indeterminate && this._clickAction !== 'check') {
+
+                Promise.resolve().then(() => {
+                    this._indeterminate = false;
+                    this.indeterminateChange.emit(this._indeterminate);
+                });
+            }
+
+            this.toggle();
+
+            // Emit our custom change event if the native input emitted one.
+            // It is important to only emit it, if the native input triggered one, because
+            // we don't want to trigger a change event, when the `checked` variable changes for example.
+            this._emitChangeEvent();
+        } else if (!this.disabled && this._clickAction === 'noop') {
+            // Reset native input when clicked with noop. The native checkbox becomes checked after
+            // click, reset it to be align with `checked` value of `mat-checkbox`.
+            this._inputElement.nativeElement.checked = this.checked;
+            this._inputElement.nativeElement.indeterminate = this.indeterminate;
+        }
+    }
+
+    /** Focuses the checkbox. */
+    focus(): void {
+        this.focusMonitor.focusVia(this._inputElement.nativeElement, 'keyboard');
+    }
+
+    _onInteractionEvent(event: Event): void {
+        // We always have to stop propagation on the change event.
+        // Otherwise the change event, from the input element, will bubble up and
+        // emit its event object to the `change` output.
+        event.stopPropagation();
+    }
+
+    /* tslint:disable */
+    private _controlValueAccessorChangeFn: (value: any) => void = () => {
+    };
+
+    /* tslint:enable */
+
+    private _emitChangeEvent() {
+        const event = new CheckboxChange();
+        event.source = this;
+        event.checked = this.checked;
+
+        this._controlValueAccessorChangeFn(this.checked);
+        this.change.emit(event);
+    }
+}

--- a/src/browser/ui/checkbox/checkbox.module.ts
+++ b/src/browser/ui/checkbox/checkbox.module.ts
@@ -1,0 +1,22 @@
+import { A11yModule } from '@angular/cdk/a11y';
+import { ObserversModule } from '@angular/cdk/observers';
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { CheckboxComponent } from './checkbox.component';
+
+
+@NgModule({
+    imports: [
+        A11yModule,
+        ObserversModule,
+        CommonModule,
+    ],
+    declarations: [
+        CheckboxComponent,
+    ],
+    exports: [
+        CheckboxComponent,
+    ],
+})
+export class CheckboxModule {
+}

--- a/src/browser/ui/checkbox/checkbox.spec.ts
+++ b/src/browser/ui/checkbox/checkbox.spec.ts
@@ -1,0 +1,389 @@
+import { Component, DebugElement } from '@angular/core';
+import { ComponentFixture, fakeAsync, flush, TestBed } from '@angular/core/testing';
+import { FormControl, FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { By } from '@angular/platform-browser';
+import { fastTestSetup } from '../../../../test/helpers';
+import { CheckboxChange, CheckboxComponent } from './checkbox.component';
+import { CheckboxModule } from './checkbox.module';
+
+
+describe('browser.ui.checkbox', () => {
+    let fixture: ComponentFixture<TestCheckboxComponent>;
+
+    fastTestSetup();
+
+    beforeAll(async () => {
+        await TestBed
+            .configureTestingModule({
+                imports: [
+                    FormsModule,
+                    ReactiveFormsModule,
+                    CheckboxModule,
+                ],
+                declarations: [
+                    TestCheckboxComponent,
+                ],
+            })
+            .compileComponents();
+    });
+
+    beforeEach(() => {
+        fixture = TestBed.createComponent(TestCheckboxComponent);
+        fixture.detectChanges();
+    });
+
+    describe('basic behavior', () => {
+        let checkboxDebugElement: DebugElement;
+        let checkboxNativeElement: HTMLElement;
+        let checkboxInstance: CheckboxComponent;
+        let testComponent: TestCheckboxComponent;
+        let inputElement: HTMLInputElement;
+        let labelElement: HTMLLabelElement;
+
+        beforeEach(() => {
+            checkboxDebugElement = fixture.debugElement.query(By.directive(CheckboxComponent));
+            checkboxNativeElement = checkboxDebugElement.nativeElement;
+            checkboxInstance = checkboxDebugElement.componentInstance;
+            testComponent = fixture.debugElement.componentInstance;
+            inputElement = <HTMLInputElement>checkboxNativeElement.querySelector('input');
+            labelElement = <HTMLLabelElement>checkboxNativeElement.querySelector('label');
+        });
+
+        it('should add and remove the checked state', () => {
+            expect(checkboxInstance.checked).toBe(false);
+            expect(checkboxNativeElement.classList).not.toContain('Checkbox--checked');
+            expect(inputElement.checked).toBe(false);
+
+            testComponent.control.patchValue(true);
+            fixture.detectChanges();
+
+            expect(checkboxInstance.checked).toBe(true);
+            expect(checkboxNativeElement.classList).toContain('Checkbox--checked');
+            expect(inputElement.checked).toBe(true);
+
+            testComponent.control.patchValue(false);
+            fixture.detectChanges();
+
+            expect(checkboxInstance.checked).toBe(false);
+            expect(checkboxNativeElement.classList).not.toContain('Checkbox--checked');
+            expect(inputElement.checked).toBe(false);
+        });
+
+        it('should add and remove indeterminate state', () => {
+            expect(checkboxNativeElement.classList).not.toContain('Checkbox--checked');
+            expect(inputElement.checked).toBe(false);
+            expect(inputElement.indeterminate).toBe(false);
+            expect(inputElement.getAttribute('aria-checked'))
+                .toBe('false', 'Expect aria-checked to be false');
+
+            testComponent.isIndeterminate = true;
+            fixture.detectChanges();
+
+            expect(checkboxNativeElement.classList).toContain('Checkbox--indeterminate');
+            expect(inputElement.checked).toBe(false);
+            expect(inputElement.indeterminate).toBe(true);
+            expect(inputElement.getAttribute('aria-checked'))
+                .toBe('mixed', 'Expect aria checked to be mixed for indeterminate checkbox');
+
+            testComponent.isIndeterminate = false;
+            fixture.detectChanges();
+
+            expect(checkboxNativeElement.classList).not.toContain('Checkbox--indeterminate');
+            expect(inputElement.checked).toBe(false);
+            expect(inputElement.indeterminate).toBe(false);
+        });
+
+        it('should set indeterminate to false when input clicked', fakeAsync(() => {
+            testComponent.isIndeterminate = true;
+            fixture.detectChanges();
+
+            expect(checkboxInstance.indeterminate).toBe(true);
+            expect(inputElement.indeterminate).toBe(true);
+            expect(testComponent.isIndeterminate).toBe(true);
+
+            inputElement.click();
+            fixture.detectChanges();
+
+            // Flush the microtasks because the forms module updates the model state asynchronously.
+            flush();
+
+            // The checked property has been updated from the model and now the view needs
+            // to reflect the state change.
+            fixture.detectChanges();
+
+            expect(checkboxInstance.checked).toBe(true);
+            expect(inputElement.indeterminate).toBe(false);
+            expect(inputElement.checked).toBe(true);
+            expect(testComponent.isIndeterminate).toBe(false);
+
+            testComponent.isIndeterminate = true;
+            fixture.detectChanges();
+
+            expect(checkboxInstance.indeterminate).toBe(true);
+            expect(inputElement.indeterminate).toBe(true);
+            expect(inputElement.checked).toBe(true);
+            expect(testComponent.isIndeterminate).toBe(true);
+            expect(inputElement.getAttribute('aria-checked'))
+                .toBe('true', 'Expect aria checked to be true');
+
+            inputElement.click();
+            fixture.detectChanges();
+
+            // Flush the microtasks because the forms module updates the model state asynchronously.
+            flush();
+
+            // The checked property has been updated from the model and now the view needs
+            // to reflect the state change.
+            fixture.detectChanges();
+
+            expect(checkboxInstance.checked).toBe(false);
+            expect(inputElement.indeterminate).toBe(false);
+            expect(inputElement.checked).toBe(false);
+            expect(testComponent.isIndeterminate).toBe(false);
+        }));
+
+        it('should not set indeterminate to false when checked is set programmatically', () => {
+            testComponent.isIndeterminate = true;
+            fixture.detectChanges();
+
+            expect(checkboxInstance.indeterminate).toBe(true);
+            expect(inputElement.indeterminate).toBe(true);
+            expect(testComponent.isIndeterminate).toBe(true);
+
+            testComponent.control.patchValue(true);
+            fixture.detectChanges();
+
+            expect(checkboxInstance.checked).toBe(true);
+            expect(inputElement.indeterminate).toBe(true);
+            expect(inputElement.checked).toBe(true);
+            expect(testComponent.isIndeterminate).toBe(true);
+
+            testComponent.control.patchValue(false);
+            fixture.detectChanges();
+
+            expect(checkboxInstance.checked).toBe(false);
+            expect(inputElement.indeterminate).toBe(true);
+            expect(inputElement.checked).toBe(false);
+            expect(testComponent.isIndeterminate).toBe(true);
+        });
+
+        it('should change native element checked when check programmatically', () => {
+            expect(inputElement.checked).toBe(false);
+
+            checkboxInstance.checked = true;
+            fixture.detectChanges();
+
+            expect(inputElement.checked).toBe(true);
+        });
+
+        it('should toggle checked state on click', () => {
+            expect(checkboxInstance.checked).toBe(false);
+
+            labelElement.click();
+            fixture.detectChanges();
+
+            expect(checkboxInstance.checked).toBe(true);
+
+            labelElement.click();
+            fixture.detectChanges();
+
+            expect(checkboxInstance.checked).toBe(false);
+        });
+
+        it('should change from indeterminate to checked on click', fakeAsync(() => {
+            testComponent.control.patchValue(false);
+            testComponent.isIndeterminate = true;
+            fixture.detectChanges();
+
+            expect(checkboxInstance.checked).toBe(false);
+            expect(checkboxInstance.indeterminate).toBe(true);
+
+            checkboxInstance._onInputClick(<Event>{stopPropagation: () => {}});
+
+            // Flush the microtasks because the indeterminate state will be updated in the next tick.
+            flush();
+
+            expect(checkboxInstance.checked).toBe(true);
+            expect(checkboxInstance.indeterminate).toBe(false);
+
+            checkboxInstance._onInputClick(<Event>{stopPropagation: () => {}});
+            fixture.detectChanges();
+
+            expect(checkboxInstance.checked).toBe(false);
+            expect(checkboxInstance.indeterminate).toBe(false);
+
+            flush();
+        }));
+
+        it('should add and remove disabled state', () => {
+            expect(checkboxInstance.disabled).toBe(false);
+            expect(checkboxNativeElement.classList).not.toContain('Checkbox--disabled');
+            expect(inputElement.tabIndex).toBe(0);
+            expect(inputElement.disabled).toBe(false);
+
+            testComponent.control.disable();
+            fixture.detectChanges();
+
+            expect(checkboxInstance.disabled).toBe(true);
+            expect(checkboxNativeElement.classList).toContain('Checkbox--disabled');
+            expect(inputElement.disabled).toBe(true);
+
+            testComponent.control.enable();
+            fixture.detectChanges();
+
+            expect(checkboxInstance.disabled).toBe(false);
+            expect(checkboxNativeElement.classList).not.toContain('Checkbox--disabled');
+            expect(inputElement.tabIndex).toBe(0);
+            expect(inputElement.disabled).toBe(false);
+        });
+
+        it('should not toggle `checked` state upon interation while disabled', () => {
+            testComponent.control.disable();
+            fixture.detectChanges();
+
+            checkboxNativeElement.click();
+            expect(checkboxInstance.checked).toBe(false);
+        });
+
+        it('should overwrite indeterminate state when clicked', fakeAsync(() => {
+            testComponent.isIndeterminate = true;
+            fixture.detectChanges();
+
+            inputElement.click();
+            fixture.detectChanges();
+
+            // Flush the microtasks because the indeterminate state will be updated in the next tick.
+            flush();
+
+            expect(checkboxInstance.checked).toBe(true);
+            expect(checkboxInstance.indeterminate).toBe(false);
+        }));
+
+        it('should preserve the user-provided id', () => {
+            expect(checkboxNativeElement.id).toBe('simple-check');
+            expect(inputElement.id).toBe('simple-check-input');
+        });
+
+        it('should project the checkbox content into the label element', () => {
+            const label = <HTMLLabelElement>checkboxNativeElement.querySelector('.Checkbox__label');
+            expect(label.textContent.trim()).toBe('Simple checkbox');
+        });
+
+        it('should make the host element a tab stop', () => {
+            expect(inputElement.tabIndex).toBe(0);
+        });
+
+        it('should not trigger the click event multiple times', () => {
+            // By default, when clicking on a label element, a generated click will be dispatched
+            // on the associated input element.
+            // Since we're using a label element and a visual hidden input, this behavior can led
+            // to an issue, where the click events on the checkbox are getting executed twice.
+
+            spyOn(testComponent, 'onCheckboxClick');
+
+            expect(inputElement.checked).toBe(false);
+            expect(checkboxNativeElement.classList).not.toContain('Checkbox--checked');
+
+            labelElement.click();
+            fixture.detectChanges();
+
+            expect(checkboxNativeElement.classList).toContain('Checkbox--checked');
+            expect(inputElement.checked).toBe(true);
+
+            expect(testComponent.onCheckboxClick).toHaveBeenCalledTimes(1);
+        });
+
+        it('should trigger a change event when the native input does', fakeAsync(() => {
+            spyOn(testComponent, 'onCheckboxChange');
+
+            expect(inputElement.checked).toBe(false);
+            expect(checkboxNativeElement.classList).not.toContain('Checkbox--checked');
+
+            labelElement.click();
+            fixture.detectChanges();
+
+            expect(inputElement.checked).toBe(true);
+            expect(checkboxNativeElement.classList).toContain('Checkbox--checked');
+
+            fixture.detectChanges();
+            flush();
+
+            // The change event shouldn't fire, because the value change was not caused
+            // by any interaction.
+            expect(testComponent.onCheckboxChange).toHaveBeenCalledTimes(1);
+        }));
+
+        it('should not trigger the change event by changing the native value', fakeAsync(() => {
+            spyOn(testComponent, 'onCheckboxChange');
+
+            expect(inputElement.checked).toBe(false);
+            expect(checkboxNativeElement.classList).not.toContain('Checkbox--checked');
+
+            testComponent.control.patchValue(true);
+            fixture.detectChanges();
+
+            expect(inputElement.checked).toBe(true);
+            expect(checkboxNativeElement.classList).toContain('Checkbox--checked');
+
+            fixture.detectChanges();
+            flush();
+
+            // The change event shouldn't fire, because the value change was not caused
+            // by any interaction.
+            expect(testComponent.onCheckboxChange).not.toHaveBeenCalled();
+        }));
+
+        it('should focus on underlying input element when focus() is called', () => {
+            expect(document.activeElement).not.toBe(inputElement);
+
+            checkboxInstance.focus();
+            fixture.detectChanges();
+
+            expect(document.activeElement).toBe(inputElement);
+        });
+
+        it('should forward the value to input element', () => {
+            testComponent.checkboxValue = 'basic_checkbox';
+            fixture.detectChanges();
+
+            expect(inputElement.value).toBe('basic_checkbox');
+        });
+
+        it('should remove the SVG checkmark from the tab order', () => {
+            expect(checkboxNativeElement.querySelector('svg').getAttribute('focusable')).toBe('false');
+        });
+    });
+});
+
+
+@Component({
+    template: `
+        <div (click)="parentElementClicked = true" (keyup)="parentElementKeyedUp = true">
+            <gd-checkbox
+                [id]="checkboxId"
+                [formControl]="control"
+                [(indeterminate)]="isIndeterminate"
+                [value]="checkboxValue"
+                (click)="onCheckboxClick($event)"
+                (change)="onCheckboxChange($event)">
+                Simple checkbox
+            </gd-checkbox>
+        </div>
+    `,
+})
+class TestCheckboxComponent {
+    readonly control = new FormControl(false);
+
+    isIndeterminate: boolean = false;
+    parentElementClicked: boolean = false;
+    parentElementKeyedUp: boolean = false;
+    checkboxId: string | null = 'simple-check';
+    checkboxValue: string = 'single_checkbox';
+
+    /* tslint:disable */
+    onCheckboxClick: (event?: Event) => void = () => {
+    };
+    onCheckboxChange: (event?: CheckboxChange) => void = () => {
+    };
+    /* tslint:enable */
+}

--- a/src/browser/ui/checkbox/index.ts
+++ b/src/browser/ui/checkbox/index.ts
@@ -1,0 +1,3 @@
+export * from './checkbox.module';
+export * from './checkbox.component';
+export * from './checkbox-config';

--- a/src/browser/ui/ui.module.ts
+++ b/src/browser/ui/ui.module.ts
@@ -6,6 +6,7 @@ import { ReactiveFormsModule } from '@angular/forms';
 import { AutocompleteModule } from './autocomplete';
 import { ButtonModule } from './button';
 import { ButtonToggleModule } from './button-toggle';
+import { CheckboxModule } from './checkbox';
 import { DialogModule } from './dialog';
 import { FormFieldModule } from './form-field';
 import { IconModule } from './icon';
@@ -51,6 +52,7 @@ const UI_MODULES = [
     TextFieldModule,
     MenuModule,
     TabsModule,
+    CheckboxModule,
 ];
 
 


### PR DESCRIPTION
## Type of PR
New Feature

## Changes
Add checkbox ui. Hard copied from [Angular Material2](https://github.com/angular/material2).

Can be integrated with ``<gd-form-field>``.

## Usage
```html
<gd-checkbox [formControl]="control" name="hello" [indeterminate]="true">Label</gd-checkbox>
```

## Screenshot
![checkbox-anim](https://user-images.githubusercontent.com/13250888/47965474-317aaf80-e08b-11e8-914c-a31ad3c386b7.gif)

![checkbox-light-theme](https://user-images.githubusercontent.com/13250888/47965755-237a5e00-e08e-11e8-8f2e-d976ea9f15b4.png)


## References
* [Angular Material2 Checkbox](https://material.angular.io/components/checkbox)