### PR TITLE
Add expansion ui

### DIFF
--- a/src/browser/ui/expansion/expansion-panel.directive.ts
+++ b/src/browser/ui/expansion/expansion-panel.directive.ts
@@ -1,0 +1,42 @@
+import { coerceBooleanProperty } from '@angular/cdk/coercion';
+import { Directive, ElementRef, Input } from '@angular/core';
+import { removeDomStyle, updateDomStyles } from '../../utils/dom-style';
+
+
+@Directive({
+    selector: '[gdExpansionPanel]',
+    exportAs: 'gdExpansionPanel',
+})
+export class ExpansionPanelDirective {
+    constructor(public _elementRef: ElementRef<HTMLElement>) {
+    }
+
+    private _expanded: boolean;
+
+    @Input()
+    get expanded(): boolean {
+        return this._expanded;
+    }
+
+    set expanded(value: boolean) {
+        this._expanded = coerceBooleanProperty(value);
+
+        if (this._expanded) {
+            this.expandPanel();
+        } else {
+            this.collapsePanel();
+        }
+    }
+
+    private expandPanel(): void {
+        removeDomStyle(this._elementRef.nativeElement, 'display');
+        removeDomStyle(this._elementRef.nativeElement, 'overflow');
+    }
+
+    private collapsePanel(): void {
+        updateDomStyles(this._elementRef.nativeElement, {
+            display: 'none',
+            overflow: 'hidden',
+        });
+    }
+}

--- a/src/browser/ui/expansion/expansion-trigger.directive.ts
+++ b/src/browser/ui/expansion/expansion-trigger.directive.ts
@@ -1,0 +1,57 @@
+import { ENTER } from '@angular/cdk/keycodes';
+import { Directive, HostListener, Input, OnInit } from '@angular/core';
+import { ExpansionPanelDirective } from './expansion-panel.directive';
+
+
+/**
+ * UI that can be expanded/collapsed.
+ *
+ * @example
+ * <button [gdExpansionTrigger]="panel">Trigger</button>
+ * <div gdExpansionPanel #panel="gdExpansionPanel">Panel</div>
+ */
+@Directive({
+    selector: '[gdExpansionTrigger]',
+    host: {
+        'class': 'ExpansionTrigger',
+        '[class.ExpansionTrigger--triggered]': 'panelOpen',
+        '[attr.aria-expanded]': 'panelOpen || null',
+    },
+})
+export class ExpansionTriggerDirective implements OnInit {
+    @Input('gdExpansionTrigger') panel: ExpansionPanelDirective;
+
+    get panelOpen(): boolean {
+        return this.panel && this.panel.expanded;
+    }
+
+    ngOnInit(): void {
+        if (!this.panel) {
+            throw new Error('Cannot find provided expansion panel!');
+        }
+    }
+
+    toggle(): void {
+        this.panel.expanded = !this.panel.expanded;
+    }
+
+    open(): void {
+        this.panel.expanded = true;
+    }
+
+    close(): void {
+        this.panel.expanded = false;
+    }
+
+    @HostListener('click')
+    _handleClick(): void {
+        this.toggle();
+    }
+
+    @HostListener('keydown', ['$event'])
+    _handleKeydown(event: KeyboardEvent): void {
+        if (event.keyCode === ENTER) {
+            this.toggle();
+        }
+    }
+}

--- a/src/browser/ui/expansion/expansion.module.ts
+++ b/src/browser/ui/expansion/expansion.module.ts
@@ -1,0 +1,21 @@
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { ExpansionPanelDirective } from './expansion-panel.directive';
+import { ExpansionTriggerDirective } from './expansion-trigger.directive';
+
+
+@NgModule({
+    imports: [
+        CommonModule,
+    ],
+    declarations: [
+        ExpansionTriggerDirective,
+        ExpansionPanelDirective,
+    ],
+    exports: [
+        ExpansionTriggerDirective,
+        ExpansionPanelDirective,
+    ],
+})
+export class ExpansionModule {
+}

--- a/src/browser/ui/expansion/expansion.spec.ts
+++ b/src/browser/ui/expansion/expansion.spec.ts
@@ -1,0 +1,104 @@
+import { ENTER } from '@angular/cdk/keycodes';
+import { CommonModule } from '@angular/common';
+import { Component } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { dispatchKeyboardEvent, expectDom, fastTestSetup } from '../../../../test/helpers';
+import { ExpansionModule } from './expansion.module';
+
+
+describe('browser.ui.expansion', () => {
+    let fixture: ComponentFixture<TestExpansionComponent>;
+    let component: TestExpansionComponent;
+
+    const getTriggerButtonEl = (): HTMLButtonElement =>
+        fixture.debugElement.query(By.css('#trigger')).nativeElement as HTMLButtonElement;
+
+    const getPanelEl = (): HTMLElement =>
+        fixture.debugElement.query(By.css('#panel')).nativeElement as HTMLElement;
+
+    fastTestSetup();
+
+    beforeAll(async () => {
+        await TestBed
+            .configureTestingModule({
+                imports: [
+                    CommonModule,
+                    ExpansionModule,
+                ],
+                declarations: [
+                    TestExpansionComponent,
+                ],
+            })
+            .compileComponents();
+    });
+
+    beforeEach(() => {
+        fixture = TestBed.createComponent(TestExpansionComponent);
+        component = fixture.componentInstance;
+    });
+
+    describe('opened -> closed', () => {
+        beforeEach(() => {
+            component.initialOpened = true;
+            fixture.detectChanges();
+        });
+
+        it('should close panel when click trigger button.', () => {
+            getTriggerButtonEl().click();
+            fixture.detectChanges();
+
+            expectDom(getPanelEl()).toBeStyled('display', 'none');
+            expectDom(getPanelEl()).toBeStyled('overflow', 'hidden');
+        });
+
+        it('should close panel when keydown \'ENTER\'.', () => {
+            dispatchKeyboardEvent(getTriggerButtonEl(), 'keydown', ENTER);
+            fixture.detectChanges();
+
+            expectDom(getPanelEl()).toBeStyled('display', 'none');
+            expectDom(getPanelEl()).toBeStyled('overflow', 'hidden');
+        });
+    });
+
+    describe('closed -> opened', () => {
+        beforeEach(() => {
+            component.initialOpened = false;
+            fixture.detectChanges();
+        });
+
+        it('should open panel when click trigger button.', () => {
+            getTriggerButtonEl().click();
+            fixture.detectChanges();
+
+            expectDom(getPanelEl()).not.toBeStyled('display', 'none');
+            expectDom(getPanelEl()).not.toBeStyled('overflow', 'hidden');
+        });
+
+        it('should open panel when keydown \'ENTER\'.', () => {
+            dispatchKeyboardEvent(getTriggerButtonEl(), 'keydown', ENTER);
+            fixture.detectChanges();
+
+            expectDom(getPanelEl()).not.toBeStyled('display', 'none');
+            expectDom(getPanelEl()).not.toBeStyled('overflow', 'hidden');
+        });
+    });
+
+    it('should trigger button contains triggered class when panel is open.', () => {
+        component.initialOpened = true;
+        fixture.detectChanges();
+
+        expectDom(getTriggerButtonEl()).toContainClasses('ExpansionTrigger--triggered');
+    });
+});
+
+
+@Component({
+    template: `
+        <button id="trigger" [gdExpansionTrigger]="panel">Toggle</button>
+        <div id="panel" gdExpansionPanel #panel="gdExpansionPanel" [expanded]="initialOpened">Panel</div>
+    `,
+})
+class TestExpansionComponent {
+    initialOpened: boolean = false;
+}

--- a/src/browser/ui/expansion/index.ts
+++ b/src/browser/ui/expansion/index.ts
@@ -1,0 +1,3 @@
+export * from './expansion.module';
+export * from './expansion-panel.directive';
+export * from './expansion-trigger.directive';

--- a/test/helpers/expect-dom.ts
+++ b/test/helpers/expect-dom.ts
@@ -46,6 +46,14 @@ class DomExpectMatcher {
             return expect(document.activeElement).toEqual(this.element);
         }
     }
+
+    toBeStyled(styleName: string, value: string): any {
+        if (this.denied) {
+            return expect(getComputedStyle(this.element)[styleName]).not.toEqual(value);
+        } else {
+            return expect(getComputedStyle(this.element)[styleName]).toEqual(value);
+        }
+    }
 }
 
 


### PR DESCRIPTION
## Overview
Add expansion ui. It only supports the expansion operation, so if you want to make things visible on the screen, you should use it based on this.

## Usage

```html
<button [gdExpansionTrigger]="gdExpansionPanel">Trigger</button>
<div gdExpansionPanel #panel="gdExpansionPanel">Panel</div>
```