### PR TITLE
Stack input on note

### DIFF
--- a/src/browser/app/app.component.ts
+++ b/src/browser/app/app.component.ts
@@ -51,7 +51,7 @@ export class AppComponent implements OnInit {
     );
 
     readonly noSelectedNote: Observable<boolean> = this.collection
-        .getSelectedNote(false)
+        .getSelectedNote()
         .pipe(map(selectedNote => selectedNote === null));
 
     constructor(

--- a/src/browser/note/note-collection/note-collection.actions.ts
+++ b/src/browser/note/note-collection/note-collection.actions.ts
@@ -20,6 +20,7 @@ export enum NoteCollectionActionTypes {
     UPDATE_CONTRIBUTION_FAIL = '[NoteCollection] Update contribution fail',
     CHANGE_NOTE_TITLE = '[NoteCollection] Change note title',
     DELETE_NOTE = '[NoteCollection] Delete note',
+    CHANGE_NOTE_STACKS = '[NoteCollection] Change note stacks',
 }
 
 
@@ -142,6 +143,17 @@ export class DeleteNoteAction implements Action {
 }
 
 
+export class ChangeNoteStacksAction implements Action {
+    readonly type = NoteCollectionActionTypes.CHANGE_NOTE_STACKS;
+
+    constructor(public readonly payload: {
+        note: NoteItem,
+        stacks: string[],
+    }) {
+    }
+}
+
+
 export type NoteCollectionAction =
     LoadNoteCollectionAction
     | LoadNoteCollectionCompleteAction
@@ -157,4 +169,5 @@ export type NoteCollectionAction =
     | UpdateNoteContributionAction
     | UpdateNoteContributionFailAction
     | ChangeNoteTitleAction
-    | DeleteNoteAction;
+    | DeleteNoteAction
+    | ChangeNoteStacksAction;

--- a/src/browser/note/note-collection/note-collection.module.ts
+++ b/src/browser/note/note-collection/note-collection.module.ts
@@ -1,6 +1,7 @@
 import { DatePipe } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { SharedModule } from '../../shared';
+import { StackSharedModule } from '../../stack/stack-shared';
 import { UiModule } from '../../ui/ui.module';
 import { NoteSharedModule } from '../note-shared';
 import { CreateNewNoteDialogComponent } from './create-new-note-dialog/create-new-note-dialog.component';
@@ -20,6 +21,7 @@ import { NoteListToolsComponent } from './note-list-tools/note-list-tools.compon
         UiModule,
         SharedModule,
         NoteSharedModule,
+        StackSharedModule,
     ],
     declarations: [
         NoteCalendarComponent,

--- a/src/browser/note/note-collection/note-collection.reducer.spec.ts
+++ b/src/browser/note/note-collection/note-collection.reducer.spec.ts
@@ -4,6 +4,7 @@ import { datetime, DateUnits } from '../../../libs/datetime';
 import { NoteItemDummy, prepareForFilteringNotes, prepareForSortingNotes } from './dummies';
 import {
     AddNoteAction,
+    ChangeNoteStacksAction,
     ChangeNoteTitleAction,
     ChangeSortDirectionAction,
     ChangeSortOrderAction,
@@ -522,6 +523,53 @@ describe('browser.note.noteCollection.noteCollectionReducer', () => {
             );
 
             expect(result.selectedNote).toBeNull();
+        });
+    });
+
+    describe('CHANGE_NOTE_STACKS', () => {
+        const dummy = new NoteItemDummy();
+        let notes: NoteItem[];
+        let beforeState: NoteCollectionState;
+
+        beforeEach(() => {
+            notes = createDummies(dummy, 10);
+            beforeState = noteCollectionReducer(
+                undefined,
+                new LoadNoteCollectionCompleteAction({ notes }),
+            );
+        });
+
+        it('should change note stack ids at index.', () => {
+            const targetNote = notes[3];
+            const result = noteCollectionReducer(
+                beforeState,
+                new ChangeNoteStacksAction({
+                    note: targetNote,
+                    stacks: ['a', 'b', 'c'],
+                }),
+            );
+
+            expect(result.notes[3].stackIds).toEqual(['a', 'b', 'c']);
+        });
+
+        it('should change note stack ids at index and selected note if index of note '
+            + 'is currently selected.', () => {
+            const targetNote = notes[7];
+            beforeState = noteCollectionReducer(
+                beforeState,
+                new SelectNoteAction({ note: targetNote }),
+            );
+
+            const result = noteCollectionReducer(
+                beforeState,
+                new ChangeNoteStacksAction({
+                    note: targetNote,
+                    stacks: ['a', 'b', 'c'],
+                }),
+            );
+
+            expect(result.selectedNote.stackIds).toEqual(['a', 'b', 'c']);
+            expect(result.notes[7].stackIds).toEqual(['a', 'b', 'c']);
         });
     });
 });

--- a/src/browser/note/note-collection/note-collection.reducer.ts
+++ b/src/browser/note/note-collection/note-collection.reducer.ts
@@ -243,6 +243,13 @@ export function noteCollectionReducer(
                 withNoteDelete(state, getIndexOfNote(state, action.payload.note)),
             );
 
+        case NoteCollectionActionTypes.CHANGE_NOTE_STACKS:
+            return withFilteredAndSortedNotes(withNoteUpdate(
+                state,
+                getIndexOfNote(state, action.payload.note),
+                { stackIds: action.payload.stacks },
+            ));
+
         default:
             return state;
     }

--- a/src/browser/note/note-collection/note-list/note-list.component.html
+++ b/src/browser/note/note-collection/note-list/note-list.component.html
@@ -1,5 +1,7 @@
 <div class="NoteList">
-    <div fxLayout fxLayoutAlign="center center" *ngIf="isEmpty" class="NoteList__emptyState">
+    <div fxLayout fxLayoutAlign="center center"
+         [class.NoteList__emptyState--hide]="!isEmpty"
+         class="NoteList__emptyState">
         No Notes
     </div>
 

--- a/src/browser/note/note-collection/note-list/note-list.component.scss
+++ b/src/browser/note/note-collection/note-list/note-list.component.scss
@@ -7,10 +7,16 @@
     min-height: 1px;
 
     &__emptyState {
+        visibility: visible;
         padding: $spacing-triple $spacing;
         font: {
             size: $font-size-md;
             weight: $font-weight-semiBold;
         };
+
+        &--hide {
+            display: none !important;
+            visibility: hidden;
+        }
     }
 }

--- a/src/browser/note/note-collection/note-list/note-list.component.ts
+++ b/src/browser/note/note-collection/note-list/note-list.component.ts
@@ -59,7 +59,7 @@ export class NoteListComponent implements OnInit, OnDestroy, AfterViewInit {
 
     ngOnInit(): void {
         this.selectedNoteSubscription = this.collection
-            .getSelectedNote(true)
+            .getSelectedNote()
             .subscribe(selectedNote => this._selectedNote = selectedNote);
     }
 

--- a/src/browser/note/note-editor/_note-editor-theme.scss
+++ b/src/browser/note/note-editor/_note-editor-theme.scss
@@ -2,10 +2,32 @@
 @import "../../ui/style/theming";
 
 @mixin gd-note-editor-theme($theme) {
+    $is-dark: map-get($theme, is-dark);
     $background: map-get($theme, background);
     $foreground: map-get($theme, foreground);
 
     .NoteEditor {
+        $bg-color: if($is-dark, gd-color($background, background), gd-color($background, background-highlight));
+        background-color: $bg-color;
+
+        &__stacks {
+            background-color: gd-color($background, background-highlight);
+            border-bottom: 1px solid gd-color($foreground, divider);
+
+            gd-form-field .FormField__content {
+                display: flex;
+                flex-wrap: wrap;
+            }
+
+            input.ChipInput {
+                color: gd-color($foreground, text);
+
+                &::placeholder {
+                    color: gd-color($foreground, disabled-text);
+                }
+            }
+        }
+
         &__titleTextarea {
             border-bottom: 1px solid gd-color($foreground, divider);
 

--- a/src/browser/note/note-editor/note-code-snippet-action-dialog/note-code-snippet-action-dialog.component.html
+++ b/src/browser/note/note-editor/note-code-snippet-action-dialog/note-code-snippet-action-dialog.component.html
@@ -32,7 +32,7 @@
 
 <gd-autocomplete #languagePanel="gdAutocomplete">
     <gd-autocomplete-item *ngFor="let stack of languageStacks" [value]="stack.name">
-        <gd-stack-chip [stack]="stack"></gd-stack-chip>
+        <gd-stack-item [stack]="stack"></gd-stack-item>
         <span style="padding: 0 5px;">{{ stack.name }}</span>
     </gd-autocomplete-item>
 </gd-autocomplete>

--- a/src/browser/note/note-editor/note-code-snippet-editor/_note-code-snippet-editor-theme.scss
+++ b/src/browser/note/note-editor/note-code-snippet-editor/_note-code-snippet-editor-theme.scss
@@ -2,6 +2,7 @@
 @import "../../../ui/style/spacing";
 
 @mixin gd-note-code-snippet-editor-theme($theme) {
+    $is-dark-theme: map-get($theme, is-dark);
     $primary: map-get($theme, primary);
     $background: map-get($theme, background);
     $foreground: map-get($theme, foreground);
@@ -13,6 +14,8 @@
         }
 
         &__wrapper {
+            background-color: gd-color($background, background);
+
             border-left: 1px solid gd-color($foreground, divider);
             border-right: 1px solid gd-color($foreground, divider);
             border-bottom: 1px solid gd-color($foreground, divider);
@@ -55,7 +58,11 @@
         }
 
         .CodeMirror-activeline-background {
-            background: gd-color($background, background-highlight, .65);
+            background: if(
+                    $is-dark-theme,
+                    gd-color($background, background-highlight, .65),
+                    gd-color($background, hover)
+            );
         }
     }
 }

--- a/src/browser/note/note-editor/note-code-snippet-editor/note-code-snippet-editor.component.html
+++ b/src/browser/note/note-editor/note-code-snippet-editor/note-code-snippet-editor.component.html
@@ -1,5 +1,5 @@
 <div fxLayout fxLayoutAlign="start center" class="NoteCodeSnippetEditor__header">
-    <gd-stack-chip [stack]="stack"></gd-stack-chip>
+    <gd-stack-item [stack]="stack"></gd-stack-item>
     <span class="NoteCodeSnippetEditor__fileName">{{ _config.codeFileName }}</span>
 </div>
 <div class="NoteCodeSnippetEditor__wrapper">

--- a/src/browser/note/note-editor/note-content.effects.ts
+++ b/src/browser/note/note-editor/note-content.effects.ts
@@ -3,6 +3,7 @@ import { Actions, Effect, ofType } from '@ngrx/effects';
 import { select, Store } from '@ngrx/store';
 import { Observable, of } from 'rxjs';
 import { catchError, debounceTime, map, mergeMap, switchMap, take, takeUntil } from 'rxjs/operators';
+import { NoteCollectionAction, NoteCollectionActionTypes } from '../note-collection';
 import { NoteState, NoteStateWithRoot } from '../note.state';
 import {
     LoadNoteContentAction,
@@ -49,12 +50,14 @@ export class NoteContentEffects {
     );
 
     @Effect()
-    saveCurrentNote: Observable<NoteEditorAction> = this.actions.pipe(
+    saveCurrentNote: Observable<NoteEditorAction | NoteCollectionAction> = this.actions.pipe(
         ofType(
             NoteEditorActionTypes.APPEND_SNIPPET,
             NoteEditorActionTypes.UPDATE_SNIPPET,
             NoteEditorActionTypes.INSERT_SNIPPET,
             NoteEditorActionTypes.REMOVE_SNIPPET,
+            NoteCollectionActionTypes.CHANGE_NOTE_TITLE,
+            NoteCollectionActionTypes.CHANGE_NOTE_STACKS,
         ),
         debounceTime(NOTE_EDITOR_SAVE_NOTE_CONTENT_THROTTLE_TIME),
         switchMap(() =>

--- a/src/browser/note/note-editor/note-editor.component.html
+++ b/src/browser/note/note-editor/note-editor.component.html
@@ -1,4 +1,37 @@
-<div class="NoteEditor__toolbar"></div>
+<div fxFlex="none" class="NoteEditor__toolbar">
+    <div fxLayout fxLayoutAlign="start start" class="NoteEditor__stacks">
+        <label gdFormFieldLabel for="note-stacks-input" fxFlex="none">Stacks:</label>
+        <gd-form-field fxFlex="1 1 auto">
+            <gd-chip-list [formControl]="stackInputControl" #stackChips>
+                <gd-chip *ngFor="let stack of stacks"
+                         [value]="stack.name"
+                         (removed)="removeStack(stack)"
+                         class="NoteEditor__stackChip">
+                    <gd-stack-item *ngIf="stack.iconFilePath" [stack]="stack"></gd-stack-item>
+                    <span>{{ stack.name }}</span>
+                    <gd-icon gdChipRemove name="close"></gd-icon>
+                </gd-chip>
+            </gd-chip-list>
+
+            <input #stackAutoTrigger="gdAutocompleteTrigger"
+                   [gdChipInputFor]="stackChips"
+                   [gdChipInputSeparatorKeyCodes]="stackInputSeparatorKeyCodes"
+                   (gdChipInputTokenEnd)="addStack($event)"
+                   [gdAutocompleteTrigger]="stackAuto"
+                   [formControl]="stackSearchControl"
+                   placeholder="Click to add stacks"
+                   id="note-stacks-input">
+
+            <gd-autocomplete #stackAuto="gdAutocomplete">
+                <gd-autocomplete-item *ngFor="let item of searchedStacks"
+                                      [value]="item.name">
+                    <gd-stack-item [stack]="item"></gd-stack-item>
+                    <span style="padding: 0 5px;">{{ item.name }}</span>
+                </gd-autocomplete-item>
+            </gd-autocomplete>
+        </gd-form-field>
+    </div>
+</div>
 
 <div fxFlex="1 1 auto" #scrollable class="NoteEditor__scrollable">
     <div class="NoteEditor__titleEdit">

--- a/src/browser/note/note-editor/note-editor.component.scss
+++ b/src/browser/note/note-editor/note-editor.component.scss
@@ -1,5 +1,7 @@
+@import "./note-header/note-header-sizes";
 @import "../../ui/style/spacing";
 @import "../../ui/style/typography";
+@import "../../ui/form-field/form-field-sizes";
 
 :host {
     display: flex;
@@ -18,6 +20,35 @@
     &__titleEdit {
         min-height: min-content;
         padding: $spacing;
+    }
+
+    &__stacks {
+        min-height: $note-header-size;
+        padding: 2.5px $spacing;
+
+        label {
+            margin-right: $spacing-half;
+        }
+
+        .ChipList {
+            margin: 2px 0;
+        }
+
+        input.ChipInput {
+            min-width: 100px;
+            background: transparent;
+            border: none;
+            outline: 0;
+            margin: 0;
+            padding: 0 $spacing-half;
+            height: $form-control-size;
+        }
+    }
+
+    &__stackChip {
+        gd-stack-item {
+            margin-right: $spacing-half;
+        }
     }
 
     &__titleTextarea {

--- a/src/browser/note/note-editor/note-editor.component.ts
+++ b/src/browser/note/note-editor/note-editor.component.ts
@@ -1,14 +1,17 @@
-import { DOWN_ARROW, ENTER } from '@angular/cdk/keycodes';
+import { COMMA, DOWN_ARROW, ENTER } from '@angular/cdk/keycodes';
 import { Component, ElementRef, OnDestroy, OnInit, ViewChild, ViewContainerRef } from '@angular/core';
 import { FormControl } from '@angular/forms';
 import { select, Store } from '@ngrx/store';
-import { from, Observable, of, Subscription } from 'rxjs';
-import { catchError, debounceTime, filter, switchMap, take, withLatestFrom } from 'rxjs/operators';
+import { from, Observable, of, Subject, Subscription } from 'rxjs';
+import { catchError, debounceTime, filter, switchMap, take, tap, withLatestFrom } from 'rxjs/operators';
 import { AssetTypes } from '../../../core/asset';
 import { NoteSnippetTypes } from '../../../core/note';
 import { toPromise } from '../../../libs/rx';
 import { MenuEvent, MenuService, NativeDialog, nativeDialogFileFilters, NativeDialogProperties } from '../../shared';
 import { ConfirmDialog } from '../../shared/confirm-dialog';
+import { Stack, StackViewer } from '../../stack';
+import { AutocompleteTriggerDirective } from '../../ui/autocomplete';
+import { ChipInputEvent } from '../../ui/chips';
 import { NoteCollectionService } from '../note-collection';
 import { NoteContentFileAlreadyExistsError } from '../note-errors';
 import { NoteStateWithRoot } from '../note.state';
@@ -28,6 +31,9 @@ import { NoteSnippetListManager } from './note-snippet-list-manager';
     selector: 'gd-note-editor',
     templateUrl: './note-editor.component.html',
     styleUrls: ['./note-editor.component.scss'],
+    host: {
+        'class': 'NoteEditor',
+    },
 })
 export class NoteEditorComponent implements OnInit, OnDestroy {
     private get filteredMenuMessages(): Observable<MenuEvent> {
@@ -40,16 +46,28 @@ export class NoteEditorComponent implements OnInit, OnDestroy {
         );
     }
 
+    searchedStacks: Stack[] = [];
+    stacks: Stack[] = [];
+
+    readonly stacksChanged = new Subject<Stack[]>();
+    readonly stackInputControl = new FormControl('');
+    readonly stackSearchControl = new FormControl('');
+    readonly stackInputSeparatorKeyCodes = [ENTER, COMMA];
+
     readonly titleInputControl = new FormControl('');
 
     @ViewChild('scrollable') scrollable: ElementRef<HTMLElement>;
     @ViewChild('snippetsList') snippetsList: ElementRef<HTMLElement>;
     @ViewChild('titleTextarea') titleTextarea: ElementRef<HTMLTextAreaElement>;
+    @ViewChild('stackAutoTrigger') stackAutocompleteTrigger: AutocompleteTriggerDirective;
 
     private listTopFocusOutSubscription = Subscription.EMPTY;
     private menuMessageSubscription = Subscription.EMPTY;
-    private titleChangeSubscription = Subscription.EMPTY;
-    private selectedNoteTitleChangedSubscription = Subscription.EMPTY;
+    private selectedNoteChangedSubscription = Subscription.EMPTY;
+
+    private titleChangesSubscription = Subscription.EMPTY;
+    private stacksChangesSubscription = Subscription.EMPTY;
+    private stackAutocompleteSearchSubscription = Subscription.EMPTY;
 
     constructor(
         private snippetListManager: NoteSnippetListManager,
@@ -61,7 +79,12 @@ export class NoteEditorComponent implements OnInit, OnDestroy {
         private editorService: NoteEditorService,
         private collectionService: NoteCollectionService,
         private confirmDialog: ConfirmDialog,
+        private stackViewer: StackViewer,
     ) {
+    }
+
+    get stackNames(): string[] {
+        return this.stacks.map(stack => stack.name);
     }
 
     ngOnInit(): void {
@@ -69,72 +92,21 @@ export class NoteEditorComponent implements OnInit, OnDestroy {
             .setContainerElement(this.snippetsList.nativeElement)
             .setViewContainerRef(this._viewContainerRef);
 
-        this.listTopFocusOutSubscription = this.snippetListManager.topFocusOut()
-            .subscribe(() => {
-                if (this.titleTextarea) {
-                    this.titleTextarea.nativeElement.focus();
-                }
-            });
-
-        this.menuMessageSubscription = this.filteredMenuMessages.pipe(
-            withLatestFrom(this.store.pipe(select(state => state.note.editor))),
-        ).subscribe(([event, editorState]) => {
-            const { activeSnippetIndex } = editorState as NoteEditorState;
-
-            if (activeSnippetIndex === null) {
-                return;
-            }
-
-            const ref = this.snippetListManager.getSnippetRefByIndex(activeSnippetIndex);
-
-            // If snippet is not exists, just ignore.
-            if (!ref) {
-                return;
-            }
-
-            switch (event as MenuEvent) {
-                case MenuEvent.NEW_TEXT_SNIPPET:
-                    this.createNewTextSnippet(ref);
-                    break;
-
-                case MenuEvent.NEW_CODE_SNIPPET:
-                    this.createNewCodeSnippet(ref);
-                    break;
-
-                case MenuEvent.INSERT_IMAGE:
-                    this.insertImageAtSnippet(ref);
-                    break;
-            }
-        });
-
-        this.selectedNoteTitleChangedSubscription = this.store.pipe(
-            select(state => state.note.collection.selectedNote),
-            filter(selectedNote => !!selectedNote),
-        ).subscribe((note) => {
-            this.titleInputControl.setValue(note.title, { emitEvent: false });
-        });
-
-        this.titleChangeSubscription = this.titleInputControl.valueChanges.pipe(
-            debounceTime(250),
-            withLatestFrom(this.store.pipe(
-                select(state => state.note.collection.selectedNote),
-            )),
-            switchMap(([newTitle, note]) =>
-                from(this.collectionService.changeNoteTitle(note, newTitle)).pipe(
-                    catchError((error) => {
-                        this.handleNoteTitleChangeError(error, newTitle);
-                        return of(null);
-                    }),
-                ),
-            ),
-        ).subscribe();
+        this.subscribeListTopFocusOut();
+        this.subscribeMenuMessage();
+        this.subscribeSelectedNoteChanged();
+        this.subscribeStackAutocompleteSearch();
+        this.subscribeStacksChanges();
+        this.subscribeTitleChanges();
     }
 
     ngOnDestroy(): void {
         this.listTopFocusOutSubscription.unsubscribe();
         this.menuMessageSubscription.unsubscribe();
-        this.selectedNoteTitleChangedSubscription.unsubscribe();
-        this.titleChangeSubscription.unsubscribe();
+        this.selectedNoteChangedSubscription.unsubscribe();
+        this.titleChangesSubscription.unsubscribe();
+        this.stacksChangesSubscription.unsubscribe();
+        this.stackAutocompleteSearchSubscription.unsubscribe();
     }
 
     moveFocusToSnippetEditor(event: KeyboardEvent): void {
@@ -143,6 +115,30 @@ export class NoteEditorComponent implements OnInit, OnDestroy {
         if (keyCode === DOWN_ARROW || keyCode === ENTER) {
             event.preventDefault();
             this.snippetListManager.focusTo(0);
+        }
+    }
+
+    addStack(event: ChipInputEvent): void {
+        const name = event.value;
+        const stack = this.stackViewer.getStackWithSafe(name);
+
+        if (!this.stacks.some(s => s.name === name)) {
+            this.stacks.push(stack);
+            this.stacksChanged.next(this.stacks);
+        }
+
+        this.stackSearchControl.patchValue('');
+    }
+
+    removeStack(stack: Stack): void {
+        const index = this.stacks.findIndex(s => s.name === stack.name);
+
+        if (index !== -1) {
+            this.stacks.splice(index, 1);
+            this.stacksChanged.next(this.stacks);
+
+            // Close panel is expected behavior.
+            this.stackAutocompleteTrigger.closePanel();
         }
     }
 
@@ -187,10 +183,9 @@ export class NoteEditorComponent implements OnInit, OnDestroy {
             return;
         }
 
-        const currentSelectedNote = await toPromise(this.store.pipe(
-            select(state => state.note.collection.selectedNote),
-            take(1),
-        ));
+        const currentSelectedNote = await toPromise(
+            this.collectionService.getSelectedNote().pipe(take(1)),
+        );
 
         if (!currentSelectedNote) {
             return;
@@ -228,5 +223,92 @@ export class NoteEditorComponent implements OnInit, OnDestroy {
             title: `Cannot update note title to: "${titleToChange}"`,
             body: message,
         });
+    }
+
+    private subscribeListTopFocusOut(): void {
+        this.listTopFocusOutSubscription = this.snippetListManager.topFocusOut()
+            .subscribe(() => {
+                if (this.titleTextarea) {
+                    this.titleTextarea.nativeElement.focus();
+                }
+            });
+    }
+
+    private subscribeMenuMessage(): void {
+        this.menuMessageSubscription = this.filteredMenuMessages.pipe(
+            withLatestFrom(this.store.pipe(select(state => state.note.editor))),
+        ).subscribe(([event, editorState]) => {
+            const { activeSnippetIndex } = editorState as NoteEditorState;
+
+            if (activeSnippetIndex === null) {
+                return;
+            }
+
+            const ref = this.snippetListManager.getSnippetRefByIndex(activeSnippetIndex);
+
+            // If snippet is not exists, just ignore.
+            if (!ref) {
+                return;
+            }
+
+            switch (event as MenuEvent) {
+                case MenuEvent.NEW_TEXT_SNIPPET:
+                    this.createNewTextSnippet(ref);
+                    break;
+
+                case MenuEvent.NEW_CODE_SNIPPET:
+                    this.createNewCodeSnippet(ref);
+                    break;
+
+                case MenuEvent.INSERT_IMAGE:
+                    this.insertImageAtSnippet(ref);
+                    break;
+            }
+        });
+    }
+
+    private subscribeSelectedNoteChanged(): void {
+        this.selectedNoteChangedSubscription = this.collectionService.getSelectedNote()
+            .subscribe((note) => {
+                if (note) {
+                    this.titleInputControl.setValue(note.title, { emitEvent: false });
+                    this.stacks = note.stackIds.map(name => this.stackViewer.getStackWithSafe(name));
+                }
+            });
+    }
+
+    private subscribeTitleChanges(): void {
+        this.titleChangesSubscription = this.titleInputControl.valueChanges.pipe(
+            debounceTime(250),
+            withLatestFrom(this.collectionService.getSelectedNote()),
+            switchMap(([newTitle, note]) =>
+                from(this.collectionService.changeNoteTitle(note, newTitle)).pipe(
+                    catchError((error) => {
+                        this.handleNoteTitleChangeError(error, newTitle);
+                        return of(null);
+                    }),
+                ),
+            ),
+        ).subscribe();
+    }
+
+    private subscribeStacksChanges(): void {
+        this.stacksChangesSubscription = this.stacksChanged.pipe(
+            debounceTime(250),
+            withLatestFrom(this.collectionService.getSelectedNote()),
+            tap(([stacks, note]) =>
+                this.collectionService.changeNoteStacks(note, stacks.map(stack => stack.name)),
+            ),
+        ).subscribe();
+    }
+
+    private subscribeStackAutocompleteSearch(): void {
+        this.stackAutocompleteSearchSubscription = this.stackSearchControl.valueChanges
+            .pipe(debounceTime(50))
+            .subscribe((value) => {
+                this.searchedStacks = this.stackViewer
+                    .search(value as string)
+                    .filter(stack => !this.stackNames.includes(stack.name));
+            });
     }
 }

--- a/src/browser/note/note-editor/note-text-snippet-editor/_note-text-snippet-editor-theme.scss
+++ b/src/browser/note/note-editor/note-text-snippet-editor/_note-text-snippet-editor-theme.scss
@@ -15,7 +15,7 @@
         }
 
         &__editor {
-            background-color: gd-color($background, background);
+            // background-color: gd-color($background, background);
         }
 
         span.cm-variable-2, span.cm-variable-3, span.cm-keyword {

--- a/src/browser/shared/fs.service.ts
+++ b/src/browser/shared/fs.service.ts
@@ -3,11 +3,11 @@ import {
     copy,
     CopyOptions,
     ensureDir,
+    move,
     pathExists,
     readdir,
     readFile,
     readJson,
-    rename,
     writeFile,
     writeJson,
 } from 'fs-extra';
@@ -61,6 +61,7 @@ export class FsService {
     }
 
     renameFile(oldFileName: string, newFileName: string): Observable<void> {
-        return from(rename(oldFileName, newFileName)).pipe(enterZone(this.ngZone));
+        return from(move(oldFileName, newFileName, { overwrite: false }))
+            .pipe(enterZone(this.ngZone));
     }
 }

--- a/src/browser/stack/stack-shared/index.ts
+++ b/src/browser/stack/stack-shared/index.ts
@@ -1,0 +1,2 @@
+export * from './stack-shared.module';
+export * from './stack-item.component';

--- a/src/browser/stack/stack-shared/stack-item.component.html
+++ b/src/browser/stack/stack-shared/stack-item.component.html
@@ -1,5 +1,5 @@
 <div [gdTooltip]="stack?.name"
      [gdTooltipDisabled]="disableTooltip"
-     class="StackChip__wrapper">
+     class="StackItem__wrapper">
     <img *ngIf="isIconExists" [attr.alt]="stack?.name" [src]="iconFileUrl">
 </div>

--- a/src/browser/stack/stack-shared/stack-item.component.scss
+++ b/src/browser/stack/stack-shared/stack-item.component.scss
@@ -1,4 +1,4 @@
-.StackChip {
+.StackItem {
     display: inline-flex;
     cursor: inherit;
 
@@ -8,7 +8,9 @@
         height: 16px;
 
         > img {
+            margin: 0 auto;
             display: block;
+            height: 100%;
         }
     }
 }

--- a/src/browser/stack/stack-shared/stack-item.component.spec.ts
+++ b/src/browser/stack/stack-shared/stack-item.component.spec.ts
@@ -4,17 +4,17 @@ import { expectDom, fastTestSetup } from '../../../../test/helpers';
 import { UiModule } from '../../ui/ui.module';
 import { StackDummy } from '../dummies';
 import { Stack } from '../stack.model';
-import { StackChipComponent } from './stack-chip.component';
+import { StackItemComponent } from './stack-item.component';
 
 
-describe('browser.stack.stackChip.StackChipComponent', () => {
-    let fixture: ComponentFixture<StackChipComponent>;
-    let component: StackChipComponent;
+describe('browser.stack.stackShared.StackItemComponent', () => {
+    let fixture: ComponentFixture<StackItemComponent>;
+    let component: StackItemComponent;
 
     const stackDummy = new StackDummy();
 
     const getIconEl = (): HTMLImageElement =>
-        fixture.debugElement.query(By.css('.StackChip__wrapper > img')).nativeElement as HTMLImageElement;
+        (fixture.debugElement.nativeElement as HTMLElement).querySelector('.StackItem__wrapper > img');
 
     fastTestSetup();
 
@@ -25,14 +25,14 @@ describe('browser.stack.stackChip.StackChipComponent', () => {
                     UiModule,
                 ],
                 declarations: [
-                    StackChipComponent,
+                    StackItemComponent,
                 ],
             })
             .compileComponents();
     });
 
     beforeEach(() => {
-        fixture = TestBed.createComponent(StackChipComponent);
+        fixture = TestBed.createComponent(StackItemComponent);
         component = fixture.componentInstance;
     });
 
@@ -43,7 +43,7 @@ describe('browser.stack.stackChip.StackChipComponent', () => {
         });
 
         it('should icon not exists.', () => {
-            expect(fixture.debugElement.query(By.css('.StackChip__wrapper > img'))).toBeNull();
+            expect(fixture.debugElement.query(By.css('.StackItem__wrapper > img'))).toBeNull();
         });
 
         it('should tooltip are not enabled because tooltip message is empty.', fakeAsync(() => {
@@ -76,7 +76,7 @@ describe('browser.stack.stackChip.StackChipComponent', () => {
         });
 
         it('should icon not exists.', () => {
-            expect(fixture.debugElement.query(By.css('.StackChip__wrapper > img'))).toBeNull();
+            expect(fixture.debugElement.query(By.css('.StackItem__wrapper > img'))).toBeNull();
         });
 
         it('should now show tooltip when input \'disableTooltip\' to true.', fakeAsync(() => {

--- a/src/browser/stack/stack-shared/stack-item.component.ts
+++ b/src/browser/stack/stack-shared/stack-item.component.ts
@@ -13,16 +13,17 @@ import { Stack } from '../stack.model';
 
 
 @Component({
-    selector: 'gd-stack-chip',
-    templateUrl: './stack-chip.component.html',
-    styleUrls: ['./stack-chip.component.scss'],
+    selector: 'gd-stack-item',
+    templateUrl: './stack-item.component.html',
+    styleUrls: ['./stack-item.component.scss'],
     encapsulation: ViewEncapsulation.None,
     changeDetection: ChangeDetectionStrategy.OnPush,
     host: {
+        'class': 'StackItem',
         '[attr.aria-label]': 'stack?.name',
     },
 })
-export class StackChipComponent implements DoCheck {
+export class StackItemComponent implements DoCheck {
     @Input() stack: Stack;
     @Input() disableTooltip = true;
 

--- a/src/browser/stack/stack-shared/stack-shared.module.ts
+++ b/src/browser/stack/stack-shared/stack-shared.module.ts
@@ -1,6 +1,6 @@
 import { NgModule } from '@angular/core';
 import { UiModule } from '../../ui/ui.module';
-import { StackChipComponent } from './stack-chip.component';
+import { StackItemComponent } from './stack-item.component';
 
 
 @NgModule({
@@ -8,12 +8,12 @@ import { StackChipComponent } from './stack-chip.component';
         UiModule,
     ],
     declarations: [
-        StackChipComponent,
+        StackItemComponent,
     ],
     exports: [
-        StackChipComponent,
+        StackItemComponent,
     ],
 })
-export class StackChipModule {
+export class StackSharedModule {
 }
 

--- a/src/browser/stack/stack-ship/index.ts
+++ b/src/browser/stack/stack-ship/index.ts
@@ -1,2 +1,0 @@
-export * from './stack-chip.module';
-export * from './stack-chip.component';

--- a/src/browser/stack/stack-viewer.ts
+++ b/src/browser/stack/stack-viewer.ts
@@ -28,6 +28,16 @@ export class StackViewer {
         return this.stacks.find(stack => stack.name === name) || null;
     }
 
+    getStackWithSafe(name: string): Stack {
+        let stack = this.getStack(name);
+
+        if (stack === null) {
+            stack = { name } as Stack;
+        }
+
+        return stack;
+    }
+
     search(query: string): Stack[] {
         return new SearchModel<Stack>()
             .registerScoringStrategy(3, (stack, _query) =>

--- a/src/browser/stack/stack.module.ts
+++ b/src/browser/stack/stack.module.ts
@@ -1,17 +1,17 @@
 import { NgModule } from '@angular/core';
-import { StackChipModule } from './stack-ship';
+import { StackSharedModule } from './stack-shared';
 import { StackViewer } from './stack-viewer';
 
 
 @NgModule({
     imports: [
-        StackChipModule,
+        StackSharedModule,
     ],
     providers: [
         StackViewer,
     ],
     exports: [
-        StackChipModule,
+        StackSharedModule,
     ],
 })
 export class StackModule {

--- a/src/browser/ui/chips/chip-list.component.scss
+++ b/src/browser/ui/chips/chip-list.component.scss
@@ -1,7 +1,7 @@
 @import "./chip-sizes";
 
 .ChipList {
-    display: block;
+    display: inline-flex;
     overflow: hidden;
 
     &__wrapper {


### PR DESCRIPTION
Closes #109 

Make stack input feature.

Also changed:
- Now, we just add suffix on note content file name when new content file name duplicates.
- Change file rename API 'rename' -> 'move'. Rename API overwrites file by default. We do not expected this behavior.
- Style snippet editor theme.

<img width="562" alt="2018-12-19 5 45 29" src="https://user-images.githubusercontent.com/13250888/50208989-fd96e780-03b5-11e9-898f-93379f43420d.png">

<img width="541" alt="2018-12-19 5 45 50" src="https://user-images.githubusercontent.com/13250888/50208991-ff60ab00-03b5-11e9-8309-5b88415e0d5b.png">
