### PR TITLE
#111 Track deleted note

### DIFF
--- a/src/browser/note/note-editor/note-header/note-header.component.html
+++ b/src/browser/note/note-editor/note-header/note-header.component.html
@@ -8,13 +8,6 @@
                 (click)="openEditorViewModeMenu()" id="note-change-editor-view-mode-button">
             <gd-icon name="eye"></gd-icon>
         </button>
-        <button gd-icon-button aria-label="View history of note">
-            <gd-icon name="history"></gd-icon>
-        </button>
-        <button gd-icon-button aria-label="More works for note">
-            <gd-icon name="ellipsis-v"></gd-icon>
-        </button>
-
         <button gd-button [disabled]="!canCommit" (click)="openCommitDialog()"
                 gdTooltip="Commit Note (⌘+K)" color="primary" class="NoteHeader__commitButton">
             Commit

--- a/src/browser/shared/git.service.ts
+++ b/src/browser/shared/git.service.ts
@@ -55,13 +55,13 @@ export class GitService implements OnDestroy {
             summary: string;
             description: string;
         },
-        filesToAdd: string[],
+        fileChanges: VcsFileChange[],
     ): Observable<string> {
         const options: GitCommitOptions = {
             workspaceDirPath,
             author,
             message: `${message.summary}${EOL}${EOL}${message.description}`,
-            filesToAdd,
+            fileChanges,
         };
 
         const commitTask = this.ipcClient.performAction<GitCommitOptions, string>(

--- a/src/browser/vcs/vcs-local/vcs-commit-dialog/vcs-commit-dialog.component.spec.ts
+++ b/src/browser/vcs/vcs-local/vcs-commit-dialog/vcs-commit-dialog.component.spec.ts
@@ -317,7 +317,7 @@ describe('browser.vcs.vcsCommit.VcsCommitDialogComponent', () => {
                 workspaceConfig.rootDirPath,
                 author,
                 { summary: 'Summary', description: 'Description' },
-                fileChanges.map(change => change.filePath),
+                fileChanges,
             );
             expect(store.dispatch).toHaveBeenCalledWith(new CommittedAction({ commitId: 'commitId' }));
 

--- a/src/browser/vcs/vcs-local/vcs-commit-dialog/vcs-commit-dialog.component.ts
+++ b/src/browser/vcs/vcs-local/vcs-commit-dialog/vcs-commit-dialog.component.ts
@@ -11,7 +11,7 @@ import {
 import { FormControl, FormGroup, Validators } from '@angular/forms';
 import { Store } from '@ngrx/store';
 import { finalize } from 'rxjs/operators';
-import { VcsAccount, VcsError } from '../../../../core/vcs';
+import { VcsAccount, VcsError, VcsFileChange } from '../../../../core/vcs';
 import { GitService, WorkspaceService } from '../../../shared';
 import { Dialog, DIALOG_DATA, DialogRef } from '../../../ui/dialog';
 import { MenuItem } from '../../../ui/menu';
@@ -148,12 +148,12 @@ export class VcsCommitDialogComponent implements OnInit, AfterViewInit {
         } as MenuItem));
     }
 
-    private getFilesToAdd(): string[] {
-        const filesToAdd: string[] = [];
+    private getFilesToAdd(): VcsFileChange[] {
+        const filesToAdd: VcsFileChange[] = [];
         const selectedItems = this.itemListManager.getSelectedItems();
 
         selectedItems.forEach((itemRef) => {
-            filesToAdd.push(...itemRef._config.fileChanges.map(change => change.filePath));
+            filesToAdd.push(...itemRef._config.fileChanges);
         });
 
         return filesToAdd;

--- a/src/core/git.ts
+++ b/src/core/git.ts
@@ -1,4 +1,4 @@
-import { VcsAccount, VcsAuthenticationInfo, VcsCommitItem } from './vcs';
+import { VcsAccount, VcsAuthenticationInfo, VcsCommitItem, VcsFileChange } from './vcs';
 
 
 type Protocol = 'ssh' | 'https';
@@ -151,7 +151,7 @@ export interface GitCommitOptions {
     message: string;
 
     /** List of files to add. Path must be relative to workspace directory path. */
-    filesToAdd: string[];
+    fileChanges: VcsFileChange[];
 
     /** Author of commit. Same account will be sign to committer. */
     author: VcsAccount;

--- a/src/main-process/services/git.service.ts
+++ b/src/main-process/services/git.service.ts
@@ -145,8 +145,13 @@ export class GitService extends Service {
             : this.git.Signature.now(option.author.name, option.author.email);
 
         const treeOId = await index.writeTree();
-        const head = await this.git.Reference.nameToId(repository, 'HEAD');
-        const parentCommit = await repository.getCommit(head);
+        let parentCommit: Commit;
+
+        try {
+            const head = await this.git.Reference.nameToId(repository, 'HEAD');
+            parentCommit = await repository.getCommit(head);
+        } catch (err) {
+        }
 
         const commitId = await repository.createCommit(
             'HEAD',
@@ -154,7 +159,7 @@ export class GitService extends Service {
             signature,
             option.message,
             treeOId,
-            [parentCommit],
+            parentCommit ? [parentCommit] : [],
         );
 
         signature.free();
@@ -349,7 +354,6 @@ export class GitService extends Service {
 
     handleError(error: any): GitError | any {
         const out = error.message;
-        console.log(error, out);
 
         if (out) {
             for (const code of Object.keys(gitErrorRegexes)) {


### PR DESCRIPTION
Closes #111

1. Get statues for un-tracked files
Add 'INCLUDE_UNTRACKED' flag for get statues in repository. By this way, we can get renamed, deleted files.

2. Remove by path if file change status is 'REMOVED'
Since delete file is untracked, you will get error when call 'addByPath' in index of repository. We should call 'removeByPath' instead of 'addByPath'.