### PR TITLE
Capture errors and report

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -38,7 +38,7 @@
                             "aot": true,
                             "extractLicenses": false,
                             "vendorChunk": false,
-                            "buildOptimizer": true,
+                            "buildOptimizer": false,
                             "progress": false
                         }
                     }

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
         "@ngrx/effects": "^6.0.1",
         "@ngrx/store": "^6.0.1",
         "@ngrx/store-devtools": "^6.0.1",
+        "@sentry/electron": "^0.14.0",
         "codemirror": "^5.40.2",
         "core-js": "^2.5.7",
         "date-fns": "^1.29.0",

--- a/src/browser/app.ts
+++ b/src/browser/app.ts
@@ -1,6 +1,7 @@
 import { enableProdMode } from '@angular/core';
 import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
 import { environment } from '../core/environment';
+import { logMonitor } from '../core/log-monitor';
 import { AppModule } from './app/app.module';
 import { workspaceDatabase } from './shared';
 
@@ -10,6 +11,9 @@ if (environment.production) {
 }
 
 
-Promise.all([workspaceDatabase.init()])
-    .then(() => platformBrowserDynamic().bootstrapModule(AppModule))
-    .catch(error => console.error(error));
+Promise.all([
+    workspaceDatabase.init(),
+    logMonitor.install('browser/app'),
+]).then(() =>
+    platformBrowserDynamic().bootstrapModule(AppModule),
+).catch(error => console.error(error));

--- a/src/browser/app/app-configs.ts
+++ b/src/browser/app/app-configs.ts
@@ -11,17 +11,20 @@ import { VcsCommitContributionMeasurement } from '../vcs/vcs-local';
 import { BaseVcsItemFactory, VCS_ITEM_MAKING_FACTORIES, VcsItemFactory } from '../vcs/vcs-view';
 
 
+export function APP_VCS_ITEM_FACTORIES_PROVIDE_FUNC(
+    noteVcsItemFactory: NoteVcsItemFactory,
+    baseVcsItemFactory: BaseVcsItemFactory,
+): VcsItemFactory<any>[] {
+    return [noteVcsItemFactory, baseVcsItemFactory];
+}
+
+
+// NOTE: member order should be 'provide'-'deps'-'useFactory',
+//  and DO NOT USE SHORTHAND FUNCTION for useFactory member.
 export const AppVcsItemFactoriesProvider: Provider = {
     provide: VCS_ITEM_MAKING_FACTORIES,
-    useFactory(
-        noteVcsItemFactory: NoteVcsItemFactory,
-        baseVcsItemFactory: BaseVcsItemFactory,
-    ): VcsItemFactory<any>[] {
-        // 1. Note related files
-        // 2. Others... (asset etc.)
-        return [noteVcsItemFactory, baseVcsItemFactory];
-    },
     deps: [NoteVcsItemFactory, BaseVcsItemFactory],
+    useFactory: APP_VCS_ITEM_FACTORIES_PROVIDE_FUNC,
 };
 
 

--- a/src/browser/app/app-settings/general-settings/general-settings.component.html
+++ b/src/browser/app/app-settings/general-settings/general-settings.component.html
@@ -8,4 +8,10 @@
             </gd-button-toggle>
         </gd-button-toggle-group>
     </div>
+
+    <div gdColumn="1 / 3" gdRow="2" fxLayout fxLayoutAlign="start center">
+        <gd-checkbox [formControl]="logMonitorStateControl">
+            Allow anonymous logging only for development purpose.
+        </gd-checkbox>
+    </div>
 </div>

--- a/src/browser/app/app-settings/general-settings/general-settings.component.ts
+++ b/src/browser/app/app-settings/general-settings/general-settings.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import { FormControl } from '@angular/forms';
 import { Subscription } from 'rxjs';
+import { logMonitor } from '../../../../core/log-monitor';
 import { ThemeService } from '../../../shared';
 import { Themes } from '../../../ui/style';
 
@@ -16,8 +17,10 @@ export class GeneralSettingsComponent implements OnInit, OnDestroy {
         { name: 'Light Theme', value: Themes.BASIC_LIGHT_THEME },
         { name: 'Dark Theme', value: Themes.BASIC_DARK_THEME },
     ];
+    readonly logMonitorStateControl = new FormControl();
 
     private themeUpdateSubscription = Subscription.EMPTY;
+    private logMonitorStateUpdateSubscription = Subscription.EMPTY;
 
     constructor(private theme: ThemeService) {
     }
@@ -25,6 +28,16 @@ export class GeneralSettingsComponent implements OnInit, OnDestroy {
     ngOnInit(): void {
         this.themeFormControl.setValue(this.theme.currentTheme);
         this.themeUpdateSubscription = this.themeFormControl.valueChanges.subscribe(this.theme.setTheme);
+
+        this.logMonitorStateControl.setValue(logMonitor.enabled);
+        this.logMonitorStateUpdateSubscription = this.logMonitorStateControl
+            .valueChanges.subscribe((enabled) => {
+                if (enabled) {
+                    logMonitor.enable();
+                } else {
+                    logMonitor.disable();
+                }
+            });
     }
 
     ngOnDestroy(): void {

--- a/src/browser/app/app.effects.ts
+++ b/src/browser/app/app.effects.ts
@@ -8,7 +8,7 @@ import { VcsActionTypes } from '../vcs';
 
 
 @Injectable()
-export class ErrorCollectEffects {
+export class AppEffects {
     @Effect({ dispatch: false })
     collectErrors = this.actions.pipe(
         ofType(

--- a/src/browser/app/app.module.ts
+++ b/src/browser/app/app.module.ts
@@ -19,6 +19,7 @@ import {
 import { AppLayoutModule } from './app-layout';
 import { AppSettingsModule } from './app-settings';
 import { AppComponent } from './app.component';
+import { AppEffects } from './app.effects';
 import { appReducer } from './app.reducer';
 
 
@@ -29,7 +30,7 @@ import { appReducer } from './app.reducer';
         UiModule,
         StoreModule.forRoot(appReducer),
         StoreDevtoolsModule.instrument(),
-        EffectsModule.forRoot([]),
+        EffectsModule.forRoot([AppEffects]),
         SharedModule,
         AppLayoutModule,
         AppSettingsModule,

--- a/src/browser/app/app.module.ts
+++ b/src/browser/app/app.module.ts
@@ -6,6 +6,7 @@ import { StoreModule } from '@ngrx/store';
 import { StoreDevtoolsModule } from '@ngrx/store-devtools';
 import { NoteModule } from '../note';
 import { SettingsModule } from '../settings';
+import { SharedModule } from '../shared';
 import { UiModule } from '../ui/ui.module';
 import { VcsModule } from '../vcs';
 import {
@@ -29,6 +30,7 @@ import { appReducer } from './app.reducer';
         StoreModule.forRoot(appReducer),
         StoreDevtoolsModule.instrument(),
         EffectsModule.forRoot([]),
+        SharedModule,
         AppLayoutModule,
         AppSettingsModule,
         NoteModule,

--- a/src/browser/note/note-collection/note-collection.service.ts
+++ b/src/browser/note/note-collection/note-collection.service.ts
@@ -67,9 +67,12 @@ export class NoteCollectionService implements OnDestroy {
 
         // 2) Get all notes.
         const noteFileNames = await toPromise(this.fs.readDirectory(notesDirPath));
+        const filteredNoteFileNames = noteFileNames.filter(
+            fileName => path.extname(fileName) === '.json',
+        );
         const readingNotes: Promise<Note | null>[] = [];
 
-        noteFileNames.forEach((fileName) => {
+        filteredNoteFileNames.forEach((fileName) => {
             const filePath = path.resolve(notesDirPath, fileName);
             readingNotes.push(toPromise(this.fs.readJsonFile<Note>(filePath)));
         });
@@ -80,8 +83,8 @@ export class NoteCollectionService implements OnDestroy {
             .filter(note => note !== null)
             .map((note: Note, index) => ({
                 ...note,
-                fileName: noteFileNames[index],
-                filePath: path.resolve(notesDirPath, noteFileNames[index]),
+                fileName: filteredNoteFileNames[index],
+                filePath: path.resolve(notesDirPath, filteredNoteFileNames[index]),
                 contentFilePath: note.label
                     ? path.resolve(
                         this.workspace.configs.rootDirPath,

--- a/src/browser/shared/error-collect.effects.ts
+++ b/src/browser/shared/error-collect.effects.ts
@@ -1,0 +1,30 @@
+import { Injectable } from '@angular/core';
+import { Actions, Effect, ofType } from '@ngrx/effects';
+import { tap } from 'rxjs/operators';
+import { logMonitor } from '../../core/log-monitor';
+import { NoteCollectionActionTypes } from '../note/note-collection';
+import { NoteEditorActionTypes } from '../note/note-editor';
+import { VcsActionTypes } from '../vcs';
+
+
+@Injectable()
+export class ErrorCollectEffects {
+    @Effect({ dispatch: false })
+    collectErrors = this.actions.pipe(
+        ofType(
+            NoteCollectionActionTypes.LOAD_COLLECTION_ERROR,
+            NoteEditorActionTypes.LOAD_NOTE_CONTENT_ERROR,
+            NoteEditorActionTypes.SAVE_NOTE_CONTENT_ERROR,
+            VcsActionTypes.LOAD_COMMIT_HISTORY_FAIL,
+            VcsActionTypes.SYNCHRONIZED_FAIL,
+            VcsActionTypes.UPDATE_FILE_CHANGES_FAIL,
+        ),
+        tap((action: any) => {
+            logMonitor.logException(action.error);
+            console.error(action.error);
+        }),
+    );
+
+    constructor(private actions: Actions) {
+    }
+}

--- a/src/browser/shared/global-error-handler.ts
+++ b/src/browser/shared/global-error-handler.ts
@@ -1,0 +1,10 @@
+import { ErrorHandler } from '@angular/core';
+import { logMonitor } from '../../core/log-monitor';
+
+
+export class GlobalErrorHandler extends ErrorHandler {
+    handleError(error: any): void {
+        logMonitor.logException(error);
+        throw error;
+    }
+}

--- a/src/browser/shared/index.ts
+++ b/src/browser/shared/index.ts
@@ -7,4 +7,3 @@ export * from './menu.service';
 export * from './native-dialog';
 export * from './theme.service';
 export * from './global-error-handler';
-export * from './error-collect.effects';

--- a/src/browser/shared/index.ts
+++ b/src/browser/shared/index.ts
@@ -6,3 +6,5 @@ export * from './git.service';
 export * from './menu.service';
 export * from './native-dialog';
 export * from './theme.service';
+export * from './global-error-handler';
+export * from './error-collect.effects';

--- a/src/browser/shared/shared.module.ts
+++ b/src/browser/shared/shared.module.ts
@@ -1,9 +1,12 @@
 import { CommonModule } from '@angular/common';
-import { NgModule } from '@angular/core';
+import { ErrorHandler, NgModule } from '@angular/core';
+import { EffectsModule } from '@ngrx/effects';
 import { ChangeFileNameDialogModule } from './change-file-name-dialog';
 import { ConfirmDialogModule } from './confirm-dialog';
+import { ErrorCollectEffects } from './error-collect.effects';
 import { FsService } from './fs.service';
 import { GitService } from './git.service';
+import { GlobalErrorHandler } from './global-error-handler';
 import { MenuService } from './menu.service';
 import { NativeDialog } from './native-dialog';
 import { ThemeService } from './theme.service';
@@ -16,6 +19,7 @@ import { WorkspaceService } from './workspace.service';
         CommonModule,
         ConfirmDialogModule,
         ChangeFileNameDialogModule,
+        EffectsModule.forFeature([ErrorCollectEffects]),
     ],
     providers: [
         FsService,
@@ -25,6 +29,10 @@ import { WorkspaceService } from './workspace.service';
         MenuService,
         NativeDialog,
         ThemeService,
+        {
+            provide: ErrorHandler,
+            useClass: GlobalErrorHandler,
+        },
     ],
     exports: [
         ConfirmDialogModule,

--- a/src/browser/shared/shared.module.ts
+++ b/src/browser/shared/shared.module.ts
@@ -1,9 +1,7 @@
 import { CommonModule } from '@angular/common';
 import { ErrorHandler, NgModule } from '@angular/core';
-import { EffectsModule } from '@ngrx/effects';
 import { ChangeFileNameDialogModule } from './change-file-name-dialog';
 import { ConfirmDialogModule } from './confirm-dialog';
-import { ErrorCollectEffects } from './error-collect.effects';
 import { FsService } from './fs.service';
 import { GitService } from './git.service';
 import { GlobalErrorHandler } from './global-error-handler';
@@ -19,7 +17,6 @@ import { WorkspaceService } from './workspace.service';
         CommonModule,
         ConfirmDialogModule,
         ChangeFileNameDialogModule,
-        EffectsModule.forFeature([ErrorCollectEffects]),
     ],
     providers: [
         FsService,

--- a/src/browser/vcs/vcs.module.ts
+++ b/src/browser/vcs/vcs.module.ts
@@ -36,6 +36,7 @@ import { VcsService } from './vcs.service';
     exports: [
         VcsRemoteModule,
         VcsViewModule,
+        VcsLocalModule,
         VcsSettingsModule,
         VcsManagerComponent,
     ],

--- a/src/browser/wizard.ts
+++ b/src/browser/wizard.ts
@@ -1,6 +1,7 @@
 import { enableProdMode } from '@angular/core';
 import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
 import { environment } from '../core/environment';
+import { logMonitor } from '../core/log-monitor';
 import { workspaceDatabase } from './shared';
 import { WizardModule } from './wizard/wizard.module';
 
@@ -9,6 +10,9 @@ if (environment.production) {
     enableProdMode();
 }
 
-Promise.all([workspaceDatabase.init()])
-    .then(() => platformBrowserDynamic().bootstrapModule(WizardModule))
-    .catch(error => console.error(error));
+Promise.all([
+    workspaceDatabase.init(),
+    logMonitor.install('browser/wizard'),
+]).then(() =>
+    platformBrowserDynamic().bootstrapModule(WizardModule),
+).catch(error => console.error(error));

--- a/src/browser/wizard/wizard-choosing/wizard-choosing.component.html
+++ b/src/browser/wizard/wizard-choosing/wizard-choosing.component.html
@@ -1,3 +1,4 @@
+<!--suppress CheckEmptyScriptTag -->
 <div fxLayout="column" fxLayoutAlign="center center" class="WizardChoosing__title">
     <svg xmlns="http://www.w3.org/2000/svg" width="280" height="50" viewBox="0 0 280 50">
         <g>
@@ -34,10 +35,15 @@
     </section>
 </div>
 
-<div fxLayout fxLayoutAlign="center center" class="WizardChoosing__footer">
+<div fxLayout="column" fxLayoutAlign="center center" fxLayoutGap="10px"
+     class="WizardChoosing__footer">
     <gd-button-toggle-group [formControl]="themeFormControl">
         <gd-button-toggle *ngFor="let option of themeOptions" [value]="option.value">
             {{ option.name }}
         </gd-button-toggle>
     </gd-button-toggle-group>
+
+    <gd-checkbox [formControl]="logMonitorStateControl">
+        Allow anonymous logging only for development purpose.
+    </gd-checkbox>
 </div>

--- a/src/browser/wizard/wizard-choosing/wizard-choosing.component.scss
+++ b/src/browser/wizard/wizard-choosing/wizard-choosing.component.scss
@@ -20,6 +20,6 @@
     }
 
     &__footer {
-        padding: $spacing 0 $spacing-double 0;
+        padding: $spacing 0 15px 0;
     }
 }

--- a/src/browser/wizard/wizard-choosing/wizard-choosing.component.ts
+++ b/src/browser/wizard/wizard-choosing/wizard-choosing.component.ts
@@ -2,6 +2,7 @@ import { Component, OnDestroy, OnInit } from '@angular/core';
 import { FormControl } from '@angular/forms';
 import { Subscription } from 'rxjs';
 import { environment } from '../../../core/environment';
+import { logMonitor } from '../../../core/log-monitor';
 import { WorkspaceError } from '../../../core/workspace';
 import { ThemeService, WorkspaceService } from '../../shared';
 import { ConfirmDialog } from '../../shared/confirm-dialog';
@@ -22,7 +23,10 @@ export class WizardChoosingComponent implements OnInit, OnDestroy {
         { name: 'Dark Theme', value: Themes.BASIC_DARK_THEME },
     ];
 
+    readonly logMonitorStateControl = new FormControl();
+
     private themeSetSubscription = Subscription.EMPTY;
+    private logMonitorStateUpdateSubscription = Subscription.EMPTY;
 
     constructor(
         private theme: ThemeService,
@@ -34,10 +38,21 @@ export class WizardChoosingComponent implements OnInit, OnDestroy {
     ngOnInit(): void {
         this.themeFormControl.patchValue(this.theme.currentTheme);
         this.themeSetSubscription = this.themeFormControl.valueChanges.subscribe(this.theme.setTheme);
+
+        this.logMonitorStateControl.patchValue(logMonitor.enabled);
+        this.logMonitorStateUpdateSubscription = this.logMonitorStateControl
+            .valueChanges.subscribe((enabled) => {
+                if (enabled) {
+                    logMonitor.enable();
+                } else {
+                    logMonitor.disable();
+                }
+            });
     }
 
     ngOnDestroy(): void {
         this.themeSetSubscription.unsubscribe();
+        this.logMonitorStateUpdateSubscription.unsubscribe();
     }
 
     createNewWorkspace(): void {

--- a/src/browser/wizard/wizard.module.ts
+++ b/src/browser/wizard/wizard.module.ts
@@ -1,9 +1,12 @@
 import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { EffectsModule } from '@ngrx/effects';
+import { combineReducers, StoreModule } from '@ngrx/store';
 import { SharedModule } from '../shared';
 import { UiModule } from '../ui/ui.module';
 import { VcsModule } from '../vcs';
+import { WizardVcsAuthenticationInfoExistsResolver } from './resolvers';
 import { WizardChoosingModule } from './wizard-choosing';
 import { WizardCloningModule } from './wizard-cloning';
 import { WizardRoutingModule } from './wizard-routing.module';
@@ -15,6 +18,8 @@ import { WizardComponent } from './wizard.component';
         BrowserModule,
         BrowserAnimationsModule,
         UiModule,
+        StoreModule.forRoot(combineReducers({})),
+        EffectsModule.forRoot([]),
         SharedModule,
         VcsModule,
         WizardChoosingModule,
@@ -22,6 +27,9 @@ import { WizardComponent } from './wizard.component';
         WizardRoutingModule,
     ],
     declarations: [WizardComponent],
+    providers: [
+        WizardVcsAuthenticationInfoExistsResolver,
+    ],
     bootstrap: [WizardComponent],
 })
 export class WizardModule {

--- a/src/browser/wizard/wizard.module.ts
+++ b/src/browser/wizard/wizard.module.ts
@@ -2,7 +2,7 @@ import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { EffectsModule } from '@ngrx/effects';
-import { combineReducers, StoreModule } from '@ngrx/store';
+import { StoreModule } from '@ngrx/store';
 import { SharedModule } from '../shared';
 import { UiModule } from '../ui/ui.module';
 import { VcsModule } from '../vcs';
@@ -18,7 +18,7 @@ import { WizardComponent } from './wizard.component';
         BrowserModule,
         BrowserAnimationsModule,
         UiModule,
-        StoreModule.forRoot(combineReducers({})),
+        StoreModule.forRoot({}),
         EffectsModule.forRoot([]),
         SharedModule,
         VcsModule,

--- a/src/core/environment.ts
+++ b/src/core/environment.ts
@@ -17,6 +17,14 @@ class Environment {
         }
     }
 
+    getSentryDsn(): string {
+        if (this.production) {
+            return 'https://c00ff5f1eec343c3ad298dc3b6e47366@sentry.io/1353720';
+        } else {
+            return 'https://e18cb98edaa7446da779d10568c4d1bb@sentry.io/1353723';
+        }
+    }
+
     getAppPath(): string {
         return app.getAppPath();
     }

--- a/src/core/environment.ts
+++ b/src/core/environment.ts
@@ -1,8 +1,9 @@
-import * as packageInfo from '../../package.json';
+import { App } from 'electron';
 import { isRendererProcess } from '../libs/process';
 
 
-let app: Electron.App;
+let app: App;
+const packageInfo = require('../../package.json');
 
 
 class Environment {

--- a/src/core/log-monitor.ts
+++ b/src/core/log-monitor.ts
@@ -1,0 +1,115 @@
+import * as Sentry from '@sentry/electron';
+import { SentryEvent } from '@sentry/electron';
+import { readJson, writeJson } from 'fs-extra';
+import * as path from 'path';
+import { from, Subject, Subscription } from 'rxjs';
+import { debounceTime, switchMap } from 'rxjs/operators';
+import { environment } from './environment';
+
+
+interface LogMonitorState {
+    enabled: boolean;
+}
+
+
+class LogMonitor {
+    private _installed: boolean = false;
+
+    get installed(): boolean {
+        return this._installed;
+    }
+
+    private _enabled: boolean = false;
+
+    get enabled(): boolean {
+        return this._enabled;
+    }
+
+    readonly stateFilePath = path.resolve(
+        environment.getPath('userData'),
+        'log-monitor-state.json',
+    );
+
+    private stateSaveStream = new Subject<LogMonitorState>();
+    private stateSaveSubscription = Subscription.EMPTY;
+
+    constructor() {
+        this.stateSaveSubscription = this.stateSaveStream.asObservable().pipe(
+            debounceTime(150),
+            switchMap(state => from(writeJson(
+                this.stateFilePath,
+                state,
+            ))),
+        ).subscribe();
+    }
+
+    logMessage(message: string): this {
+        console.log(this._installed, this._enabled);
+
+        if (this._installed && this._enabled) {
+            Sentry.captureMessage(message);
+        }
+        return this;
+    }
+
+    logException(exception: any): this {
+        if (this._installed && this._enabled) {
+            Sentry.captureException(exception);
+        }
+        return this;
+    }
+
+    async install(basePath: string): Promise<void> {
+        if (this._installed) {
+            return;
+        }
+
+        let state: LogMonitorState;
+
+        try {
+            state = await readJson(this.stateFilePath, { throws: true });
+        } catch (error) {
+            state = { enabled: false };
+            await writeJson(this.stateFilePath, state);
+        }
+
+        this._enabled = state.enabled;
+
+        Sentry.init({
+            dsn: environment.getSentryDsn(),
+            release: environment.version,
+            beforeSend(event: SentryEvent): SentryEvent {
+                if (event.user) {
+                    delete event.user.ip_address;
+                }
+
+                if (event.exception && event.exception.values) {
+                    event.exception.values.forEach((value) => {
+                        if (value.stacktrace && value.stacktrace.frames) {
+                            value.stacktrace.frames.forEach((frame) => {
+                                frame.filename = path.join('/', basePath, path.basename(frame.filename));
+                            });
+                        }
+                    });
+                }
+
+                return event;
+            },
+        });
+
+        this._installed = true;
+    }
+
+    enable(): void {
+        this._enabled = true;
+        this.stateSaveStream.next({ enabled: true });
+    }
+
+    disable(): void {
+        this._enabled = false;
+        this.stateSaveStream.next({ enabled: false });
+    }
+}
+
+
+export const logMonitor = new LogMonitor();

--- a/src/main-process/app-delegate.ts
+++ b/src/main-process/app-delegate.ts
@@ -16,7 +16,7 @@ class AppDelegate extends EventEmitter {
 
     // Services
     readonly git = new GitService();
-    readonly workspace = new WorkspaceService();
+    readonly workspace = new WorkspaceService(this.git);
     readonly menu = new MenuService();
 
     currentOpenWindow: Window | null = null;
@@ -81,7 +81,7 @@ class AppDelegate extends EventEmitter {
         this.menu.init();
 
         await Promise.all([
-            this.workspace.init(this.git),
+            this.workspace.init(),
         ]);
     }
 

--- a/src/main-process/main.ts
+++ b/src/main-process/main.ts
@@ -1,4 +1,6 @@
 import { app } from 'electron';
+import { environment } from '../core/environment';
+import { logMonitor } from '../core/log-monitor';
 import { appDelegate } from './app-delegate';
 import './dev-extensions';
 
@@ -6,6 +8,7 @@ import './dev-extensions';
 process.on('uncaughtException', (error) => {
     appDelegate.preventQuit = true;
 
+    logMonitor.logException(error);
     console.error('Uncaught Exception: ', error.toString());
 
     if (error.stack) {
@@ -14,7 +17,12 @@ process.on('uncaughtException', (error) => {
 });
 
 
-app.commandLine.appendSwitch('remote-debugging-port', '9229');
+if (!environment.production) {
+    app.commandLine.appendSwitch('remote-debugging-port', '9229');
+}
+
+
+logMonitor.install('main-process');
 
 
 app.once('ready', async () => {

--- a/src/main-process/services/git.service.ts
+++ b/src/main-process/services/git.service.ts
@@ -18,6 +18,7 @@ import {
     GitSyncWithRemoteOptions,
     GitSyncWithRemoteResult,
 } from '../../core/git';
+import { logMonitor } from '../../core/log-monitor';
 import {
     VcsAuthenticationInfo,
     VcsAuthenticationTypes,
@@ -368,6 +369,8 @@ export class GitService extends Service {
                 }
             }
         }
+
+        logMonitor.logException(error);
 
         return error;
     }

--- a/src/main-process/services/menu.service.ts
+++ b/src/main-process/services/menu.service.ts
@@ -174,6 +174,21 @@ export class MenuService extends Service {
                         },
                     ],
                 },
+                separator,
+                {
+                    id: 'show-devtools',
+                    label: __DARWIN__
+                        ? 'Toggle Developer Tools'
+                        : '&Toggle developer tools',
+                    accelerator: (() => {
+                        return __DARWIN__ ? 'Alt+Command+I' : 'Ctrl+Shift+I';
+                    })(),
+                    click(item: any, focusedWindow: BrowserWindow) {
+                        if (focusedWindow) {
+                            focusedWindow.webContents.toggleDevTools();
+                        }
+                    },
+                },
             ],
         };
 

--- a/src/main-process/windows/app.window.ts
+++ b/src/main-process/windows/app.window.ts
@@ -10,9 +10,6 @@ export class AppWindow extends Window {
             width: 1280,
             height: 768,
             show: false,
-            webPreferences: {
-                devTools: !environment.production,
-            },
             titleBarStyle: 'hidden',
             title: 'Geeks Diary',
         });

--- a/src/main-process/windows/wizard.window.ts
+++ b/src/main-process/windows/wizard.window.ts
@@ -11,9 +11,6 @@ export class WizardWindow extends Window {
             maximizable: false,
             show: false,
             fullscreenable: false,
-            webPreferences: {
-                devTools: !environment.production,
-            },
             titleBarStyle: 'hidden',
             title: 'Geeks Diary',
         });

--- a/src/main-process/windows/wizard.window.ts
+++ b/src/main-process/windows/wizard.window.ts
@@ -5,7 +5,7 @@ import { Window } from './window';
 export class WizardWindow extends Window {
     constructor() {
         super('browser/wizard/wizard.html', {
-            width: environment.production ? 600 : 1000,
+            width: 600,
             height: 415,
             resizable: false,
             maximizable: false,

--- a/webpack.electron.js
+++ b/webpack.electron.js
@@ -47,7 +47,8 @@ const config = {
     },
     target: 'electron-main',
     externals: {
-        nodegit: 'require("nodegit")'
+        nodegit: 'require("nodegit")',
+        '@sentry/electron': 'require("@sentry/electron")',
     }
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -427,6 +427,89 @@
     semver "^5.3.0"
     semver-intersect "^1.1.2"
 
+"@sentry/browser@~4.3.4":
+  version "4.3.4"
+  resolved "https://registry.npmjs.org/@sentry/browser/-/browser-4.3.4.tgz#5c17184781c4fb6ad8ab48f5c48e01630d4fc3dc"
+  integrity sha512-odRXxnhcSYzyR4YvTolNEyrz3fdDVw308l+9RBRJA9yOFVlezaz1mXH6Gv00F7cIj9yE/JtezDyhP339WsWy3w==
+  dependencies:
+    "@sentry/core" "4.3.4"
+    "@sentry/types" "4.3.4"
+    "@sentry/utils" "4.3.4"
+    tslib "^1.9.3"
+
+"@sentry/core@4.3.4", "@sentry/core@~4.3.4":
+  version "4.3.4"
+  resolved "https://registry.npmjs.org/@sentry/core/-/core-4.3.4.tgz#414e050b9e963ac7f839331ad33590e59d883988"
+  integrity sha512-KwolQmAnXiFMeXBuxPUM8fW+2bOICdHfpjdf83qD7WSeuKqGvXhxXyApWNSLE+l2DPO6/8UKnIGmR8bEn0G7QA==
+  dependencies:
+    "@sentry/hub" "4.3.4"
+    "@sentry/minimal" "4.3.4"
+    "@sentry/types" "4.3.4"
+    "@sentry/utils" "4.3.4"
+    tslib "^1.9.3"
+
+"@sentry/electron@^0.14.0":
+  version "0.14.0"
+  resolved "https://registry.npmjs.org/@sentry/electron/-/electron-0.14.0.tgz#138581e4cd69beb486afc26226fc9d2832a4d574"
+  integrity sha512-f0Aj2gKcX9LampOEFER0m6cC4etT1B3bsuY7E1R3vzZXcL7y5TaH2Omgk5atzAX5ycBk8LHxhVqUtE6fZBWlFA==
+  dependencies:
+    "@sentry/browser" "~4.3.4"
+    "@sentry/core" "~4.3.4"
+    "@sentry/minimal" "~4.3.4"
+    "@sentry/node" "~4.3.4"
+    "@sentry/types" "~4.3.4"
+    "@sentry/utils" "~4.3.4"
+    electron-fetch "1.1.0"
+    form-data "2.3.2"
+    util.promisify "1.0.0"
+
+"@sentry/hub@4.3.4":
+  version "4.3.4"
+  resolved "https://registry.npmjs.org/@sentry/hub/-/hub-4.3.4.tgz#48915f5867e8ef1d964c89394e8500d1d050719b"
+  integrity sha512-vaBGCnhinLB8N4aQLMiPPhnlTkIUwU/dxWzw/xsuKY3MYWrmfMUyWgMZF60Mz3B4F0lW1lsg5jnJz9xPnjZowg==
+  dependencies:
+    "@sentry/types" "4.3.4"
+    "@sentry/utils" "4.3.4"
+    tslib "^1.9.3"
+
+"@sentry/minimal@4.3.4", "@sentry/minimal@~4.3.4":
+  version "4.3.4"
+  resolved "https://registry.npmjs.org/@sentry/minimal/-/minimal-4.3.4.tgz#8375c3d040621dd30eeddaebf4ef1bf22be0f643"
+  integrity sha512-EBmQgdAQgxkhWFsBO4TmsP3cg5yTzg48HmPe3Dyt7PtF5Umw3DFW6qboAqnN1+KF+pHNuxkqevvgBTFp7b4Saw==
+  dependencies:
+    "@sentry/hub" "4.3.4"
+    "@sentry/types" "4.3.4"
+    tslib "^1.9.3"
+
+"@sentry/node@~4.3.4":
+  version "4.3.4"
+  resolved "https://registry.npmjs.org/@sentry/node/-/node-4.3.4.tgz#627b75114c4ac3dcc63db0a9257d852ffd0aaaa7"
+  integrity sha512-4ro8eFnIuuYrF/TLw788xU10AYJl9HvOYC5G3jLrHXTjRNLp7jJo9lZrUexjCvwM2WF/srF3+Z0Pwr+HwdKVVw==
+  dependencies:
+    "@sentry/core" "4.3.4"
+    "@sentry/hub" "4.3.4"
+    "@sentry/types" "4.3.4"
+    "@sentry/utils" "4.3.4"
+    "@types/stack-trace" "0.0.29"
+    cookie "0.3.1"
+    lsmod "1.0.0"
+    md5 "2.2.1"
+    stack-trace "0.0.10"
+    tslib "^1.9.3"
+
+"@sentry/types@4.3.4", "@sentry/types@~4.3.4":
+  version "4.3.4"
+  resolved "https://registry.npmjs.org/@sentry/types/-/types-4.3.4.tgz#563f9def51da301cfd474ecf35ae4d97847aed61"
+  integrity sha512-qsqrcyNilpbzYjqef+km0Grh5BckSFD4MUdJDNkUE5XU/ImniYddj18bMDlQxluJlTPDjUFQ37FXtEmxLeOwkQ==
+
+"@sentry/utils@4.3.4", "@sentry/utils@~4.3.4":
+  version "4.3.4"
+  resolved "https://registry.npmjs.org/@sentry/utils/-/utils-4.3.4.tgz#4473d9f4d1b909e51b6aea7051ebe1bd838d56e9"
+  integrity sha512-CMGMdIv5RHUCKRF4aWPZ/gFRTfBQpLVVJEGCeFGZLXHBdpgQac0lf3jlu8sND0KZ0S3C5x3tGS/eEqmOZRQ/pw==
+  dependencies:
+    "@sentry/types" "4.3.4"
+    tslib "^1.9.3"
+
 "@types/chai@^4.1.4":
   version "4.1.6"
   resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.1.6.tgz#1eb26c040e3a84205b1008ad55c800e5e8a94e34"
@@ -493,6 +576,11 @@
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/@types/remarkable/-/remarkable-1.7.0.tgz#a8ad2beb31f7ff784747fc2e6d98b23a1684072c"
   integrity sha512-EvsUZ0VI5KkO1GFJn6toYdum10ABrcjb/g6R866V39y9GJfu117Rh62r8P9AfkWXxY4TSTbPIOIwoaIMWpHZmg==
+
+"@types/stack-trace@0.0.29":
+  version "0.0.29"
+  resolved "https://registry.npmjs.org/@types/stack-trace/-/stack-trace-0.0.29.tgz#eb7a7c60098edb35630ed900742a5ecb20cfcb4d"
+  integrity sha512-TgfOX+mGY/NyNxJLIbDWrO9DjGoVSW9+aB8H2yy1fy32jsvxijhmyJI9fDFgvz3YP4lvJaq9DzdR/M1bOgVc9g==
 
 "@webassemblyjs/ast@1.4.3":
   version "1.4.3"
@@ -1717,6 +1805,11 @@ chalk@~2.2.2:
     escape-string-regexp "^1.0.5"
     supports-color "^4.0.0"
 
+charenc@~0.0.1:
+  version "0.0.2"
+  resolved "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz#c0a1d2f3a7092e03774bfa83f14c0fc5790a8667"
+  integrity sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc=
+
 check-error@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/check-error/-/check-error-1.0.2.tgz#574d312edd88bb5dd8912e9286dd6c0aed4aac82"
@@ -2254,6 +2347,11 @@ cross-unzip@0.0.2:
   resolved "https://registry.yarnpkg.com/cross-unzip/-/cross-unzip-0.0.2.tgz#5183bc47a09559befcf98cc4657964999359372f"
   integrity sha1-UYO8R6CVWb78+YzEZXlkmZNZNy8=
 
+crypt@~0.0.1:
+  version "0.0.2"
+  resolved "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz#88d7ff7ec0dfb86f713dc87bbb42d044d3e6c41b"
+  integrity sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs=
+
 cryptiles@2.x.x:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/cryptiles/-/cryptiles-2.0.5.tgz#3bdfecdc608147c1c67202fa291e7dca59eaa3b8"
@@ -2736,6 +2834,13 @@ electron-download@^3.0.1:
     semver "^5.3.0"
     sumchecker "^1.2.0"
 
+electron-fetch@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.npmjs.org/electron-fetch/-/electron-fetch-1.1.0.tgz#74b0ea547fe149620d38596a84fb104d34218e31"
+  integrity sha512-eBtqbB522c/RJwC5v1yF/Y0SMVLiwel98BWGx050GucWbKlejHtPkfpq/vfMxCjg0SGpHGUISYUaMfu65QH+xg==
+  dependencies:
+    encoding "^0.1.12"
+
 electron-mocha@^6.0.4:
   version "6.0.4"
   resolved "https://registry.yarnpkg.com/electron-mocha/-/electron-mocha-6.0.4.tgz#5130ff3ed1ffc2971de26881cd7d18c0c0179baf"
@@ -2806,6 +2911,13 @@ encodeurl@~1.0.1, encodeurl@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59"
   integrity sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=
+
+encoding@^0.1.12:
+  version "0.1.12"
+  resolved "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz#538b66f3ee62cd1ab51ec323829d1f9480c74beb"
+  integrity sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=
+  dependencies:
+    iconv-lite "~0.4.13"
 
 end-of-stream@^1.0.0, end-of-stream@^1.1.0:
   version "1.4.1"
@@ -3418,6 +3530,15 @@ forever-agent@~0.6.1:
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
   integrity sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=
 
+form-data@2.3.2, form-data@~2.3.1, form-data@~2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.2.tgz#4970498be604c20c005d4f5c23aecd21d6b49099"
+  integrity sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "1.0.6"
+    mime-types "^2.1.12"
+
 form-data@~2.1.1:
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.1.4.tgz#33c183acf193276ecaa98143a69e94bfee1750d1"
@@ -3425,15 +3546,6 @@ form-data@~2.1.1:
   dependencies:
     asynckit "^0.4.0"
     combined-stream "^1.0.5"
-    mime-types "^2.1.12"
-
-form-data@~2.3.1, form-data@~2.3.2:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.2.tgz#4970498be604c20c005d4f5c23aecd21d6b49099"
-  integrity sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=
-  dependencies:
-    asynckit "^0.4.0"
-    combined-stream "1.0.6"
     mime-types "^2.1.12"
 
 forwarded@~0.1.2:
@@ -4084,7 +4196,7 @@ iconv-lite@0.4.23:
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
-iconv-lite@^0.4.4:
+iconv-lite@^0.4.4, iconv-lite@~0.4.13:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
@@ -4268,7 +4380,7 @@ is-binary-path@^1.0.0:
   dependencies:
     binary-extensions "^1.0.0"
 
-is-buffer@^1.1.5:
+is-buffer@^1.1.5, is-buffer@~1.1.1:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
   integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
@@ -5193,6 +5305,11 @@ lru-cache@4.1.x, lru-cache@^4.0.1, lru-cache@^4.1.1:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
 
+lsmod@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/lsmod/-/lsmod-1.0.0.tgz#9a00f76dca36eb23fa05350afe1b585d4299e64b"
+  integrity sha1-mgD3bco26yP6BTUK/htYXUKZ5ks=
+
 make-dir@^1.0.0, make-dir@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-1.3.0.tgz#79c1033b80515bd6d24ec9933e860ca75ee27f0c"
@@ -5254,6 +5371,15 @@ md5.js@^1.3.4:
     hash-base "^3.0.0"
     inherits "^2.0.1"
     safe-buffer "^5.1.2"
+
+md5@2.2.1:
+  version "2.2.1"
+  resolved "https://registry.npmjs.org/md5/-/md5-2.2.1.tgz#53ab38d5fe3c8891ba465329ea23fac0540126f9"
+  integrity sha1-U6s41f48iJG6RlMp6iP6wFQBJvk=
+  dependencies:
+    charenc "~0.0.1"
+    crypt "~0.0.1"
+    is-buffer "~1.1.1"
 
 "mdurl@~ 1.0.0":
   version "1.0.1"
@@ -7669,6 +7795,11 @@ ssri@^5.2.4:
   dependencies:
     safe-buffer "^5.1.1"
 
+stack-trace@0.0.10:
+  version "0.0.10"
+  resolved "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz#547c70b347e8d32b4e108ea1a2a159e5fdde19c0"
+  integrity sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=
+
 static-extend@^0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/static-extend/-/static-extend-0.1.2.tgz#60809c39cbff55337226fd5e0b520f341f1fb5c6"
@@ -8123,7 +8254,7 @@ tsickle@^0.32.1:
     source-map "^0.6.0"
     source-map-support "^0.5.0"
 
-tslib@^1.7.1, tslib@^1.8.0, tslib@^1.8.1, tslib@^1.9.0:
+tslib@^1.7.1, tslib@^1.8.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
   integrity sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==


### PR DESCRIPTION
Closes #116 

Use sentry to collect errors. Considering user privacy, only user can allow/disallow logging.

Sentry collect these informations:
<img width="809" alt="2018-12-21 3 10 10" src="https://user-images.githubusercontent.com/13250888/50327459-92beeb00-0532-11e9-90fa-c97280f6cae3.png">


And fixes some bugs:
- f69d70e Fix static injection error
- 33868f8 If initial note, since only one file of note is exists, git cannot track it. So we will gonna create initial commit when initialize workspace.
- 596c52b If remote has not 'refs/heads/master', pull will fail.
- aa7f5fd Fix provider injection error on production run time