### PR TITLE
Handle exception when github not provide 'user:email' scope

### DIFF
--- a/src/browser/app/app-layout/app-layout-sidenav/app-layout-sidenav.component.html
+++ b/src/browser/app/app-layout/app-layout-sidenav/app-layout-sidenav.component.html
@@ -18,6 +18,7 @@
         </ul>
 
         <button gd-icon-button aria-label="Open Settings" [bigSize]="true"
+                gdTooltip="Preferences (⌘+,)" gdTooltipPosition="right"
                 (click)="openSettingsDialog()" class="AppLayoutSidenav__settingsButton">
             <gd-icon name="cog" [bigSize]="true"></gd-icon>
         </button>

--- a/src/browser/shared/confirm-dialog/confirm-dialog.ts
+++ b/src/browser/shared/confirm-dialog/confirm-dialog.ts
@@ -15,6 +15,7 @@ export class ConfirmDialog {
             boolean>(
             ConfirmDialogComponent,
             {
+                maxWidth: '320px',
                 data: { ...new ConfirmDialogData(), ...data },
             },
         );

--- a/src/browser/vcs/vcs-remote/github-accounts-dialog/github-accounts-dialog.component.html
+++ b/src/browser/vcs/vcs-remote/github-accounts-dialog/github-accounts-dialog.component.html
@@ -16,7 +16,7 @@
         </div>
     </div>
 
-    <form gdArea gdRows="repeat(4, 1fr)" gdColumns="1fr 3fr 2fr" gdGap="5px" (submit)="login()"
+    <form gdArea gdRows="repeat(4, 1fr)" gdColumns="1fr 3fr 2fr" gdGap="5px" (ngSubmit)="login()"
           [formGroup]="addAccountFormGroup" class="GithubAccountsDialog__form">
 
         <label gdRow="1" gdColumn="1" gdFormFieldLabel>Auth Type:</label>
@@ -60,5 +60,5 @@
 </gd-dialog-content>
 
 <gd-dialog-actions align="end">
-    <button gd-button (click)="closeThis()">Close</button>
+    <button gd-button (click)="closeThis()" type="button">Close</button>
 </gd-dialog-actions>

--- a/src/browser/vcs/vcs-remote/vcs-remote-provider.ts
+++ b/src/browser/vcs/vcs-remote/vcs-remote-provider.ts
@@ -18,6 +18,9 @@ export abstract class VcsRemoteProvider {
     /** Authorize vcs remote service with oauth2 token. */
     abstract authorizeByOauth2Token(token: string): Observable<VcsAccount>;
 
+    /** Get email list address for a user. */
+    abstract getPrimaryEmail(authInfo: VcsAuthenticationInfo): Observable<string>;
+
     /** Check is url of repository is valid. */
     abstract isRepositoryUrlValid(url: string): boolean;
 

--- a/src/browser/vcs/vcs.service.spec.ts
+++ b/src/browser/vcs/vcs.service.spec.ts
@@ -30,6 +30,10 @@ class TestVcsRemoteProvider extends VcsRemoteProvider {
         throw new Error('Please create spy.');
     }
 
+    getPrimaryEmail(authInfo: VcsAuthenticationInfo): Observable<string> {
+        throw new Error('Please create spy.');
+    }
+
     isRepositoryUrlValid(url: string): boolean {
         throw new Error('Please create spy.');
     }
@@ -168,6 +172,25 @@ describe('browser.vcs.VcsService', () => {
             expect(vcs._removeProvider.authorizeByOauth2Token).toHaveBeenCalledWith(token);
             expect(accountDB.accounts.add).not.toHaveBeenCalledWith(account);
 
+            subscription.unsubscribe();
+        }));
+    });
+
+    describe('getPrimaryEmailFromRemote', () => {
+        let callback: jasmine.Spy;
+        let account: VcsAccount;
+
+        beforeEach(() => {
+            callback = jasmine.createSpy('callback');
+            account = accountDummy.create();
+        });
+
+        it('should get primary email from remote.', fakeAsync(() => {
+            spyOn(vcs, 'getPrimaryEmailFromRemote').and.returnValue(of('abc@test.com'));
+
+            const subscription = vcs.getPrimaryEmailFromRemote(account).subscribe(callback);
+
+            expect(callback).toHaveBeenCalledWith('abc@test.com');
             subscription.unsubscribe();
         }));
     });

--- a/src/browser/vcs/vcs.service.ts
+++ b/src/browser/vcs/vcs.service.ts
@@ -105,6 +105,12 @@ export class VcsService {
         }
     }
 
+    getPrimaryEmailFromRemote(account: VcsAccount): Observable<string> {
+        this.checkIfRemoteProviderIsProvided();
+
+        return this._removeProvider.getPrimaryEmail(account.authentication);
+    }
+
     fetchFileChanges(): Observable<VcsFileChange[]> {
         return this.git.getFileChanges(this.workspace.configs.rootDirPath);
     }

--- a/src/core/vcs.ts
+++ b/src/core/vcs.ts
@@ -10,7 +10,7 @@ export enum VcsAuthenticationTypes {
  */
 export interface VcsAccount {
     readonly name: string;
-    readonly email: string;
+    readonly email?: string;
     readonly authentication: VcsAuthenticationInfo;
 }
 
@@ -162,6 +162,7 @@ export interface VcsFileChange {
 export enum VcsErrorCodes {
     AUTHENTICATE_ERROR = 'vcs.authenticateError',
     REPOSITORY_NOT_EXISTS = 'vcs.repositoryNotExists',
+    PRIMARY_EMAIL_NOT_EXISTS = 'vcs.primaryEmailNotExists',
 }
 
 
@@ -183,6 +184,16 @@ export class VcsRepositoryNotExistsError extends Error {
 }
 
 
+export class VcsPrimaryEmailNotExistsError extends Error {
+    public readonly code = VcsErrorCodes.PRIMARY_EMAIL_NOT_EXISTS;
+
+    constructor() {
+        super('Primary email not exists.');
+    }
+}
+
+
 export type VcsError =
     VcsAuthenticateError
-    | VcsRepositoryNotExistsError;
+    | VcsRepositoryNotExistsError
+    | VcsPrimaryEmailNotExistsError;


### PR DESCRIPTION
Closes #129 , #123 

Github api not always return user email.
- If user set primary email as private.
- If user not provided `user:email` scope on personal access token.

This PR handles those exceptions.