### PR TITLE
Handle error message friendly

### DIFF
--- a/src/browser/vcs/vcs-manager.component.html
+++ b/src/browser/vcs/vcs-manager.component.html
@@ -18,7 +18,7 @@
         [processing]="workspaceSynchronizing"
         [type]="syncResultMessageType"
         [successResult]="syncWorkspaceResult"
-        [error]="syncWorkspaceErrorCaught"
+        [errorMessage]="syncWorkspaceErrorMessage"
         class="VcsManager__syncResultMessage"></gd-vcs-sync-message-box>
 
     <!-- Changes Tab -->

--- a/src/browser/vcs/vcs-manager.component.ts
+++ b/src/browser/vcs/vcs-manager.component.ts
@@ -12,6 +12,7 @@ import { FormControl } from '@angular/forms';
 import { select, Store } from '@ngrx/store';
 import { Observable, Subject, Subscription } from 'rxjs';
 import { filter, finalize, switchMap, take, tap } from 'rxjs/operators';
+import { ErrorWithMetadata } from '../../core/error-with-metadata';
 import { GitSyncWithRemoteResult } from '../../core/git';
 import { VcsCommitItem } from '../../core/vcs';
 import { __DARWIN__ } from '../../libs/platform';
@@ -58,7 +59,7 @@ export class VcsManagerComponent implements OnInit, OnDestroy, AfterViewInit {
     syncResultMessageType: VcsSyncMessageBoxType;
     syncResultMessageDismissed = true;
     syncWorkspaceResult: GitSyncWithRemoteResult | null = null;
-    syncWorkspaceErrorCaught: { message: string } | null = null;
+    syncWorkspaceErrorMessage: string;
 
     private allCommitsItemAreLoaded = false;
     private commitItemsAreLoading = false;
@@ -228,7 +229,7 @@ export class VcsManagerComponent implements OnInit, OnDestroy, AfterViewInit {
         this.syncResultMessageType = null;
         this._workspaceSynchronizing = true;
         this.syncWorkspaceResult = null;
-        this.syncWorkspaceErrorCaught = null;
+        this.syncWorkspaceErrorMessage = null;
 
         this.vcs
             .syncRepository()
@@ -241,7 +242,9 @@ export class VcsManagerComponent implements OnInit, OnDestroy, AfterViewInit {
                 },
                 (error) => {
                     this.syncResultMessageType = 'error';
-                    this.syncWorkspaceErrorCaught = { message: error.message ? error.message : 'Unknown Error' };
+                    this.syncWorkspaceErrorMessage = (error as ErrorWithMetadata).errorDescription
+                        ? (error as ErrorWithMetadata).errorDescription
+                        : 'Unknown Error';
                     this.store.dispatch(new SynchronizedFailAction(error));
                 },
             );

--- a/src/browser/vcs/vcs-view/vcs-sync-message-box/vcs-sync-message-box.component.html
+++ b/src/browser/vcs/vcs-view/vcs-sync-message-box/vcs-sync-message-box.component.html
@@ -20,7 +20,7 @@
                [attr.title]="successResult?.remoteUrl">See Remote</a>
         </ng-container>
         <ng-container *ngSwitchCase="'error'">
-            {{ error?.message }}
+            {{ errorMessage }}
             <!-- TODO : External editor -->
         </ng-container>
     </p>

--- a/src/browser/vcs/vcs-view/vcs-sync-message-box/vcs-sync-message-box.component.ts
+++ b/src/browser/vcs/vcs-view/vcs-sync-message-box/vcs-sync-message-box.component.ts
@@ -1,6 +1,6 @@
-import { shell } from 'electron';
 import { Component, EventEmitter, Input, OnInit, Output, ViewEncapsulation } from '@angular/core';
-import { GitError, GitSyncWithRemoteResult } from '../../../../core/git';
+import { shell } from 'electron';
+import { GitSyncWithRemoteResult } from '../../../../core/git';
 
 
 export type VcsSyncMessageBoxType = 'success' | 'error';
@@ -18,12 +18,6 @@ export type VcsSyncMessageBoxType = 'success' | 'error';
     },
 })
 export class VcsSyncMessageBoxComponent implements OnInit {
-    @Input() processing: boolean;
-    @Input() type: VcsSyncMessageBoxType;
-    @Input() successResult: GitSyncWithRemoteResult | null = null;
-    @Input() error: GitError | null = null;
-    @Output() readonly dismiss = new EventEmitter<void>();
-
     get headIconName(): string {
         switch (this.type) {
             case 'success':
@@ -44,8 +38,15 @@ export class VcsSyncMessageBoxComponent implements OnInit {
 
     get contentExists(): boolean {
         return (this.type === 'success' && !!this.successResult)
-            || (this.type === 'error' && !!this.error);
+            || (this.type === 'error' && !!this.errorMessage);
     }
+
+    @Input() processing: boolean;
+    @Input() type: VcsSyncMessageBoxType;
+    @Input() successResult: GitSyncWithRemoteResult | null = null;
+    @Input() errorMessage: string;
+
+    @Output() readonly dismiss = new EventEmitter<void>();
 
     ngOnInit(): void {
     }

--- a/src/browser/wizard/wizard-choosing/wizard-choosing.component.spec.ts
+++ b/src/browser/wizard/wizard-choosing/wizard-choosing.component.spec.ts
@@ -6,7 +6,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { of, throwError } from 'rxjs';
 import { fastTestSetup, NoopComponent, NoopModule, sample, sampleWithout } from '../../../../test/helpers';
 import { MockDialog } from '../../../../test/mocks/browser';
-import { WorkspaceError, WorkspaceErrorCodes, WorkspaceInfo } from '../../../core/workspace';
+import { WorkspaceAlreadyExistsError, WorkspaceInfo } from '../../../core/workspace';
 import { SharedModule, ThemeService, WORKSPACE_DATABASE, WorkspaceDatabase, WorkspaceService } from '../../shared';
 import { ConfirmDialogComponent, ConfirmDialogData } from '../../shared/confirm-dialog';
 import { ButtonToggleComponent } from '../../ui/button-toggle';
@@ -99,7 +99,7 @@ describe('browser.wizard.wizardChoosing.WizardChoosingComponent', () => {
             + 'workspace button.', fakeAsync(() => {
             fixture.detectChanges();
 
-            const error = new WorkspaceError(WorkspaceErrorCodes.WORKSPACE_ALREADY_EXISTS);
+            const error = new WorkspaceAlreadyExistsError();
 
             spyOn(workspace, 'initWorkspace').and.returnValue(throwError(error));
 
@@ -114,7 +114,7 @@ describe('browser.wizard.wizardChoosing.WizardChoosingComponent', () => {
 
             expect(alertDialogRef).toBeDefined();
             expect(alertDialogRef.config.data.isAlert).toBe(true);
-            expect(alertDialogRef.config.data.body).toEqual(error.message);
+            expect(alertDialogRef.config.data.body).toEqual(error.errorDescription);
         }));
     });
 

--- a/src/browser/wizard/wizard-choosing/wizard-choosing.component.ts
+++ b/src/browser/wizard/wizard-choosing/wizard-choosing.component.ts
@@ -2,8 +2,8 @@ import { Component, OnDestroy, OnInit } from '@angular/core';
 import { FormControl } from '@angular/forms';
 import { Subscription } from 'rxjs';
 import { environment } from '../../../core/environment';
+import { ErrorWithMetadata } from '../../../core/error-with-metadata';
 import { logMonitor } from '../../../core/log-monitor';
-import { WorkspaceError } from '../../../core/workspace';
 import { ThemeService, WorkspaceService } from '../../shared';
 import { ConfirmDialog } from '../../shared/confirm-dialog';
 import { Themes } from '../../ui/style';
@@ -67,7 +67,9 @@ export class WizardChoosingComponent implements OnInit, OnDestroy {
         this.confirmDialog.open({
             title: 'Workspace Error',
             isAlert: true,
-            body: (error as WorkspaceError).message,
+            body: (error as ErrorWithMetadata).errorDescription
+                ? (error as ErrorWithMetadata).errorDescription
+                : 'Unknown Error',
         });
     }
 }

--- a/src/browser/wizard/wizard-cloning/wizard-cloning.component.spec.ts
+++ b/src/browser/wizard/wizard-cloning/wizard-cloning.component.spec.ts
@@ -357,7 +357,7 @@ describe('browser.wizard.wizardCloning.WizardCloningComponent', () => {
 
             expect(alertDialogRef).toBeDefined();
             expect(alertDialogRef.config.data.isAlert).toBe(true);
-            expect(alertDialogRef.config.data.body).toEqual(error.message);
+            expect(alertDialogRef.config.data.body).toEqual(error.errorDescription);
         }));
 
         it('should call init workspace after clone complete.', fakeAsync(() => {

--- a/src/browser/wizard/wizard-cloning/wizard-cloning.component.ts
+++ b/src/browser/wizard/wizard-cloning/wizard-cloning.component.ts
@@ -2,9 +2,8 @@ import { Component, OnInit } from '@angular/core';
 import { FormControl, FormGroup, ValidatorFn, Validators } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
 import { finalize } from 'rxjs/operators';
-import { GitError } from '../../../core/git';
+import { ErrorWithMetadata } from '../../../core/error-with-metadata';
 import { VcsAuthenticationTypes } from '../../../core/vcs';
-import { WorkspaceError } from '../../../core/workspace';
 import { WorkspaceService } from '../../shared';
 import { ConfirmDialog } from '../../shared/confirm-dialog';
 import { VcsService } from '../../vcs';
@@ -16,29 +15,6 @@ import { VcsService } from '../../vcs';
     styleUrls: ['./wizard-cloning.component.scss'],
 })
 export class WizardCloningComponent implements OnInit {
-    readonly remoteUrlFormControl = new FormControl('', { updateOn: 'blur' });
-    readonly workspaceDirectoryFormControl = new FormControl('');
-
-    readonly authenticationTypes = VcsAuthenticationTypes;
-    readonly authenticationFormGroup = new FormGroup({
-        type: new FormControl(this.authenticationTypes.BASIC),
-        userName: new FormControl(''),
-        password: new FormControl(''),
-        token: new FormControl(''),
-    });
-
-    private alreadyLogin: boolean = false;
-    private _loginSuccess: boolean = false;
-
-    constructor(
-        private vcs: VcsService,
-        private activatedRoute: ActivatedRoute,
-        private confirmDialog: ConfirmDialog,
-        private workspace: WorkspaceService,
-        private router: Router,
-    ) {
-    }
-
     get loginCompleted(): boolean {
         return this.alreadyLogin || this._loginSuccess;
     }
@@ -69,6 +45,27 @@ export class WizardCloningComponent implements OnInit {
 
     get cloneProcessing(): boolean {
         return this._cloneProcessing;
+    }
+
+    readonly remoteUrlFormControl = new FormControl('', { updateOn: 'blur' });
+    readonly workspaceDirectoryFormControl = new FormControl('');
+    readonly authenticationTypes = VcsAuthenticationTypes;
+    readonly authenticationFormGroup = new FormGroup({
+        type: new FormControl(this.authenticationTypes.BASIC),
+        userName: new FormControl(''),
+        password: new FormControl(''),
+        token: new FormControl(''),
+    });
+    private alreadyLogin: boolean = false;
+    private _loginSuccess: boolean = false;
+
+    constructor(
+        private vcs: VcsService,
+        private activatedRoute: ActivatedRoute,
+        private confirmDialog: ConfirmDialog,
+        private workspace: WorkspaceService,
+        private router: Router,
+    ) {
     }
 
     ngOnInit(): void {
@@ -175,7 +172,9 @@ export class WizardCloningComponent implements OnInit {
         this.confirmDialog.open({
             isAlert: true,
             title: 'Git Error',
-            body: (error as GitError).message,
+            body: (error as ErrorWithMetadata).errorDescription
+                ? (error as ErrorWithMetadata).errorDescription
+                : 'Unknown Error',
         });
     }
 
@@ -183,7 +182,9 @@ export class WizardCloningComponent implements OnInit {
         this.confirmDialog.open({
             isAlert: true,
             title: 'Workspace Error',
-            body: (error as WorkspaceError).message,
+            body: (error as ErrorWithMetadata).errorDescription
+                ? (error as ErrorWithMetadata).errorDescription
+                : 'Unknown Error',
         });
     }
 }

--- a/src/core/error-with-metadata.ts
+++ b/src/core/error-with-metadata.ts
@@ -1,0 +1,8 @@
+export abstract class ErrorWithMetadata extends Error {
+    public abstract code: string;
+    public abstract errorDescription: string;
+
+    protected constructor(public readonly message: string) {
+        super(message);
+    }
+}

--- a/src/core/git.ts
+++ b/src/core/git.ts
@@ -1,3 +1,4 @@
+import { ErrorWithMetadata } from './error-with-metadata';
 import { VcsAccount, VcsAuthenticationInfo, VcsCommitItem, VcsFileChange } from './vcs';
 
 
@@ -92,38 +93,42 @@ export const gitErrorRegexes: { [key: string]: RegExp } = {
 /* tslint:enable */
 
 
-interface GitErrorImpl {
-    readonly code: GitErrorCodes;
-}
+export class GitAuthenticationFailError extends ErrorWithMetadata {
+    public readonly code = GitErrorCodes.AUTHENTICATION_FAIL;
+    public readonly errorDescription = 'Authentication failed. Please check your credential.';
 
-
-export class GitAuthenticationFailError extends Error implements GitErrorImpl {
-    constructor(public readonly code = GitErrorCodes.AUTHENTICATION_FAIL) {
+    constructor() {
         super('Authentication failed. Please check your credential.');
-        this.name = 'GitError';
     }
 }
 
 
-export class GitRemoteNotFoundError extends Error implements GitErrorImpl {
-    constructor(
-        public readonly code = GitErrorCodes.REMOTE_NOT_FOUND,
-        remoteName?: string,
-    ) {
+export class GitRemoteNotFoundError extends ErrorWithMetadata {
+    public readonly code = GitErrorCodes.REMOTE_NOT_FOUND;
+    public readonly errorDescription: string;
+
+    constructor(remoteName?: string) {
         super(remoteName ? `Remote \'${remoteName}\' does not exist.` : 'Remote does not exist.');
+        this.errorDescription = this.message;
     }
 }
 
 
-export class GitMergeConflictedError extends Error implements GitErrorImpl {
-    constructor(public readonly code = GitErrorCodes.MERGE_CONFLICTED) {
+export class GitMergeConflictedError extends ErrorWithMetadata {
+    public readonly code = GitErrorCodes.MERGE_CONFLICTED;
+    public readonly errorDescription = 'Conflicts happens during merge branches.';
+
+    constructor() {
         super('Conflicts happens during merge branches.');
     }
 }
 
 
-export class GitNetworkError extends Error implements GitErrorImpl {
-    constructor(public readonly code = GitErrorCodes.NETWORK_ERROR) {
+export class GitNetworkError extends ErrorWithMetadata {
+    public readonly code = GitErrorCodes.NETWORK_ERROR;
+    public readonly errorDescription = 'Network error.';
+
+    constructor() {
         super('Network error.');
     }
 }

--- a/src/core/vcs.ts
+++ b/src/core/vcs.ts
@@ -1,3 +1,6 @@
+import { ErrorWithMetadata } from './error-with-metadata';
+
+
 export enum VcsAuthenticationTypes {
     BASIC = 'BASIC',
     OAUTH2_TOKEN = 'OAUTH2_TOKEN',
@@ -166,8 +169,9 @@ export enum VcsErrorCodes {
 }
 
 
-export class VcsAuthenticateError extends Error {
+export class VcsAuthenticateError extends ErrorWithMetadata {
     public readonly code = VcsErrorCodes.AUTHENTICATE_ERROR;
+    public readonly errorDescription = 'Authentication failed.';
 
     constructor() {
         super('Authenticate failed.');
@@ -175,8 +179,9 @@ export class VcsAuthenticateError extends Error {
 }
 
 
-export class VcsRepositoryNotExistsError extends Error {
+export class VcsRepositoryNotExistsError extends ErrorWithMetadata {
     public readonly code = VcsErrorCodes.REPOSITORY_NOT_EXISTS;
+    public readonly errorDescription = 'Cannot find repository.';
 
     constructor() {
         super('Cannot find repository.');
@@ -184,8 +189,9 @@ export class VcsRepositoryNotExistsError extends Error {
 }
 
 
-export class VcsPrimaryEmailNotExistsError extends Error {
+export class VcsPrimaryEmailNotExistsError extends ErrorWithMetadata {
     public readonly code = VcsErrorCodes.PRIMARY_EMAIL_NOT_EXISTS;
+    public readonly errorDescription = 'Primary email not exists';
 
     constructor() {
         super('Primary email not exists.');

--- a/src/core/workspace.ts
+++ b/src/core/workspace.ts
@@ -1,5 +1,6 @@
 import * as path from 'path';
 import { environment } from './environment';
+import { ErrorWithMetadata } from './error-with-metadata';
 
 
 /**
@@ -31,22 +32,18 @@ export interface WorkspaceInfo {
 
 
 export enum WorkspaceErrorCodes {
-    WORKSPACE_ALREADY_EXISTS,
+    WORKSPACE_ALREADY_EXISTS = 'workspace.workspaceAlreadyExists',
 }
 
 
-export class WorkspaceError extends Error {
-    constructor(public code: WorkspaceErrorCodes) {
-        super(getDescriptionForError(code));
+export class WorkspaceAlreadyExistsError extends ErrorWithMetadata {
+    public readonly code = WorkspaceErrorCodes.WORKSPACE_ALREADY_EXISTS;
+    public readonly errorDescription = 'Workspace already exists and is not an empty directory.';
+
+    constructor() {
+        super('Workspace already exists and is not an empty directory.');
     }
 }
 
 
-function getDescriptionForError(code: WorkspaceErrorCodes): string {
-    switch (code) {
-        case WorkspaceErrorCodes.WORKSPACE_ALREADY_EXISTS:
-            return 'Workspace already exists and is not an empty directory.';
-        default:
-            return 'Unknown Error';
-    }
-}
+export type WorkspaceError = WorkspaceAlreadyExistsError;

--- a/src/main-process/services/workspace.service.ts
+++ b/src/main-process/services/workspace.service.ts
@@ -42,7 +42,7 @@ export class WorkspaceService extends Service {
         await ensureDir(GEEKS_DIARY_DIR_PATH);
         await ensureDir(NOTES_DIR_PATH);
 
-        if (!await this.git.isRepositoryExists(WORKSPACE_DIR_PATH)) {
+        if (!await this.isWorkspaceExists()) {
             await this.git.createRepository(WORKSPACE_DIR_PATH);
 
             // Keep notes directory with '.gitkeep'.


### PR DESCRIPTION
Closes #136

Electron cannot communicate prototypes of javascript objects through IPC. It will convert to plain object.

So 'message' field inside error object is not tracked.

This PR makes our handlerable errors to have 'errorDescription' field so that can be handled event if converted to plain object.