### PR TITLE
Keep directory when note label included

### DIFF
--- a/src/browser/app/app-configs.ts
+++ b/src/browser/app/app-configs.ts
@@ -45,6 +45,7 @@ export const AppVcsHistoryChangedEffectActionsProvider: Provider = {
     provide: VCS_HISTORY_CHANGED_EFFECT_ACTIONS,
     useValue: [
         NoteCollectionActionTypes.LOAD_COLLECTION_COMPLETE, // Initial load
+        NoteCollectionActionTypes.ADD_NOTE,
     ],
 };
 

--- a/src/browser/shared/fs.service.ts
+++ b/src/browser/shared/fs.service.ts
@@ -8,6 +8,7 @@ import {
     readdir,
     readFile,
     readJson,
+    remove,
     writeFile,
     writeJson,
 } from 'fs-extra';
@@ -63,5 +64,9 @@ export class FsService {
     renameFile(oldFileName: string, newFileName: string): Observable<void> {
         return from(move(oldFileName, newFileName, { overwrite: false }))
             .pipe(enterZone(this.ngZone));
+    }
+
+    removeFile(fileName: string): Observable<void> {
+        return from(remove(fileName)).pipe(enterZone(this.ngZone));
     }
 }

--- a/src/main-process/services/workspace.service.ts
+++ b/src/main-process/services/workspace.service.ts
@@ -1,7 +1,7 @@
 import { ensureDir, ensureFile } from 'fs-extra';
 import * as path from 'path';
 import { VcsFileChangeStatusTypes } from '../../core/vcs';
-import { GEEKS_DIARY_DIR_PATH, NOTES_DIR_PATH, WORKSPACE_DIR_PATH } from '../../core/workspace';
+import { ASSETS_DIR_PATH, GEEKS_DIARY_DIR_PATH, NOTES_DIR_PATH, WORKSPACE_DIR_PATH } from '../../core/workspace';
 import { IpcActionHandler } from '../../libs/ipc';
 import { GitService } from './git.service';
 import { Service } from './service';
@@ -16,14 +16,14 @@ export enum WorkspaceEvents {
  * Workspace service.
  */
 export class WorkspaceService extends Service {
-    constructor(private git: GitService) {
-        super('workspace');
-    }
-
     private _initialized = false;
 
     get initialized(): boolean {
         return this._initialized;
+    }
+
+    constructor(private git: GitService) {
+        super('workspace');
     }
 
     async init(): Promise<void> {
@@ -48,15 +48,25 @@ export class WorkspaceService extends Service {
             // Keep notes directory with '.gitkeep'.
             // You cannot track the first Note File without this.
             await ensureFile(path.resolve(NOTES_DIR_PATH, '.gitkeep'));
+            await ensureFile(path.resolve(ASSETS_DIR_PATH, '.gitkeep'));
+
             await this.git.commit({
                 workspaceDirPath: WORKSPACE_DIR_PATH,
                 message: 'Initial commit',
-                fileChanges: [{
-                    workingDirectoryPath: WORKSPACE_DIR_PATH,
-                    filePath: '.geeks-diary/notes/.gitkeep',
-                    absoluteFilePath: path.resolve(NOTES_DIR_PATH, '.gitkeep'),
-                    status: VcsFileChangeStatusTypes.NEW,
-                }],
+                fileChanges: [
+                    {
+                        workingDirectoryPath: WORKSPACE_DIR_PATH,
+                        filePath: '.geeks-diary/notes/.gitkeep',
+                        absoluteFilePath: path.resolve(NOTES_DIR_PATH, '.gitkeep'),
+                        status: VcsFileChangeStatusTypes.NEW,
+                    },
+                    {
+                        workingDirectoryPath: WORKSPACE_DIR_PATH,
+                        filePath: '.geeks-diary/assets/.gitkeep',
+                        absoluteFilePath: path.resolve(ASSETS_DIR_PATH, '.gitkeep'),
+                        status: VcsFileChangeStatusTypes.NEW,
+                    },
+                ],
                 author: {
                     name: 'Geeks Diary',
                     email: '(BLANK)',

--- a/test/mocks/browser/mock-fs.service.ts
+++ b/test/mocks/browser/mock-fs.service.ts
@@ -174,6 +174,13 @@ export class MockFsService extends FsService {
         );
     }
 
+    removeFile(fileName: string): Observable<void> {
+        return this.createAttachment<void>(
+            'removeFile',
+            [fileName],
+        );
+    }
+
     _deleteStub<R>(stub: FsStub<R>): void {
         const attach = this.findAttachment(stub.matchObj);
 


### PR DESCRIPTION
Closes #137

### Problem
Git cannot track directories that are newly created.

When new note is created with label (this makes subdirectory), that note file cannot be tracked.

### Solve
Add `.gitkeep` file on newly created directory so that can be tracked.
