### PR TITLE
#141 Support win32 and linux.

### DIFF
--- a/scripts/package.ts
+++ b/scripts/package.ts
@@ -1,5 +1,6 @@
 import * as Builder from 'electron-builder';
 import { copy, ensureDir, readdir, readJson, remove } from 'fs-extra';
+import * as os from 'os';
 import * as path from 'path';
 import * as rimraf from 'rimraf';
 import { promisify } from 'util';
@@ -130,6 +131,11 @@ async function build(): Promise<void> {
     );
 
     console.log('Build started...');
+    const buildTargets = {
+        mac: os.platform() === 'darwin' ? ['dmg'] : undefined,
+        linux: ['snap', 'AppImage'],
+        win: ['nsis'],
+    };
     await Builder.build({
         config: {
             appId: packageInfo.appId,
@@ -146,6 +152,12 @@ async function build(): Promise<void> {
                 darkModeSupport: true,
                 icon: path.resolve(SRC_PATH, 'assets/logos/icon-logo.icns'),
             },
+            appImage: {
+                artifactName: '${name}_${version}.${ext}',
+            },
+            win: {
+                artifactName: '${name}_${version}_${arch}.${ext}',
+            },
             extraMetadata: {
                 name: packageInfo.name,
                 description: packageInfo.description,
@@ -154,6 +166,7 @@ async function build(): Promise<void> {
                 repository: packageInfo.repository,
             },
         },
+        ...buildTargets,
     });
 }
 


### PR DESCRIPTION
As I mentioned at #141, I think it is good to support win32 and linux platforms and it is easily achieved because electron already supports it. But there are few things I customized that I learned before,

- It can build a binary for macOS only in macOS environment.
- If you want to deploy it via [Microsoft Store](https://www.microsoft.com/en-us/store/b/home), you should build an `AppX` package but it is hard to manage. So I think `nsis` is more easy to deploy via GitHub releases.
- `AppImage` is a convenient format to deploy it into linux platform but its _sanitized name_ is not good, so I override it.
- [`snap`](https://snapcraft.io) is the awesome platform like apt but it is more easily to delivery a package. So I add it but if you don't want to manage it please tell me, I will remove it.

I cannot see an automation to upload these files into GitHub releases but I think you have a plan for that with adding an `auto-update` feature. If not so, please comment it, I'll fix it.